### PR TITLE
Improve behaviour for custom apps

### DIFF
--- a/src/commands/app/create/node.tsx
+++ b/src/commands/app/create/node.tsx
@@ -5,24 +5,29 @@ import {
   AppInstaller,
 } from "../../../lib/app/Installer.js";
 
-const installer = new AppInstaller(
+export const nodeInstaller = new AppInstaller(
   "3e7f920b-a711-4d2f-9871-661e1b41a2f0",
-  "Node.js Project",
-  ["version", "site-title", "wait"] as const,
+  "custom Node.js",
+  ["site-title", "wait"] as const,
 );
 
 export default class InstallNode extends ExecRenderBaseCommand<
   typeof InstallNode,
   AppInstallationResult
 > {
-  static description = installer.description;
-  static flags = installer.flags;
+  static description = nodeInstaller.description;
+  static flags = nodeInstaller.flags;
 
   protected async exec(): Promise<{ appInstallationId: string }> {
-    return installer.exec(this.apiClient, this.args, this.flags, this.config);
+    return nodeInstaller.exec(
+      this.apiClient,
+      this.args,
+      this.flags,
+      this.config,
+    );
   }
 
   protected render(result: AppInstallationResult): React.ReactNode {
-    return installer.render(result, this.flags);
+    return nodeInstaller.render(result, this.flags);
   }
 }

--- a/src/commands/app/create/php.tsx
+++ b/src/commands/app/create/php.tsx
@@ -5,24 +5,29 @@ import {
   AppInstaller,
 } from "../../../lib/app/Installer.js";
 
-const installer = new AppInstaller(
+export const phpInstaller = new AppInstaller(
   "34220303-cb87-4592-8a95-2eb20a97b2ac",
-  "PHP Project",
-  ["version", "site-title", "wait"] as const,
+  "custom PHP",
+  ["site-title", "wait"] as const,
 );
 
 export default class InstallPhp extends ExecRenderBaseCommand<
   typeof InstallPhp,
   AppInstallationResult
 > {
-  static description = installer.description;
-  static flags = installer.flags;
+  static description = phpInstaller.description;
+  static flags = phpInstaller.flags;
 
   protected async exec(): Promise<{ appInstallationId: string }> {
-    return installer.exec(this.apiClient, this.args, this.flags, this.config);
+    return phpInstaller.exec(
+      this.apiClient,
+      this.args,
+      this.flags,
+      this.config,
+    );
   }
 
   protected render(result: AppInstallationResult): React.ReactNode {
-    return installer.render(result, this.flags);
+    return phpInstaller.render(result, this.flags);
   }
 }

--- a/src/commands/app/list.ts
+++ b/src/commands/app/list.ts
@@ -7,6 +7,8 @@ import { SuccessfulResponse } from "../../types.js";
 import { ListColumns } from "../../Formatter.js";
 import AppApp = MittwaldAPIV2.Components.Schemas.AppApp;
 import AppAppVersion = MittwaldAPIV2.Components.Schemas.AppAppVersion;
+import { phpInstaller } from "./create/php.js";
+import { nodeInstaller } from "./create/node.js";
 
 type ResponseItem = Simplify<
   MittwaldAPIV2.Paths.V2ProjectsProjectIdAppinstallations.Get.Responses.$200.Content.ApplicationJson[number]
@@ -89,6 +91,10 @@ export default class List extends ListBaseCommand<
       appVersion: {
         header: "Version",
         get: (i) => {
+          if ([phpInstaller.appId, nodeInstaller.appId].includes(i.appId)) {
+            return "n/a";
+          }
+
           if (i.appVersionCurrent?.id === i.appVersionDesired.id) {
             return i.appVersionDesired.externalVersion;
           }

--- a/src/lib/app/Installer.tsx
+++ b/src/lib/app/Installer.tsx
@@ -27,7 +27,7 @@ export class AppInstaller<TFlagName extends AvailableFlagName> {
   public readonly description: string;
 
   private static makeDescription(appName: string): string {
-    return `Creates new ${appName} Installation.`;
+    return `Creates new ${appName} installation.`;
   }
 
   constructor(
@@ -48,7 +48,7 @@ export class AppInstaller<TFlagName extends AvailableFlagName> {
   public async exec(
     apiClient: MittwaldAPIV2Client,
     args: ArgOutput,
-    flags: OutputFlags<RelevantFlagInput<(TFlagName | "version" | "wait")[]>>,
+    flags: OutputFlags<RelevantFlagInput<(TFlagName | "wait")[]>>,
     config: Config,
   ): Promise<AppInstallationResult> {
     const process = makeProcessRenderer(flags, `Installing ${this.appName}`);
@@ -71,7 +71,7 @@ export class AppInstaller<TFlagName extends AvailableFlagName> {
 
     const appVersion: AppAppVersion = await normalizeToAppVersionUuid(
       apiClient,
-      flags.version as unknown as string,
+      "version" in flags ? (flags.version as string) : "latest",
       process,
       this.appId,
     );

--- a/src/rendering/react/components/AppInstallation/AppInstallationDetails.tsx
+++ b/src/rendering/react/components/AppInstallation/AppInstallationDetails.tsx
@@ -5,14 +5,19 @@ import { AppInstallationStatus } from "./AppInstallationStatus.js";
 import { SingleResult, SingleResultTable } from "../SingleResult.js";
 import { AppSystemSoftware } from "./AppSystemSoftware.js";
 import { MittwaldAPIV2 } from "@mittwald/api-client";
-import { Box } from "ink";
+import { Box, Text } from "ink";
 import AppAppInstallation = MittwaldAPIV2.Components.Schemas.AppAppInstallation;
 import AppApp = MittwaldAPIV2.Components.Schemas.AppApp;
+import { phpInstaller } from "../../../../commands/app/create/php.js";
+import { nodeInstaller } from "../../../../commands/app/create/node.js";
 
 export const AppInstallationDetails: FC<{
   appInstallation: AppAppInstallation;
   app: AppApp;
 }> = ({ app, appInstallation }) => {
+  const customInstallation = [phpInstaller.appId, nodeInstaller.appId].includes(
+    app.id,
+  );
   const desiredAppVersion = useAppVersion(
     app.id,
     appInstallation.appVersion.desired,
@@ -33,7 +38,9 @@ export const AppInstallationDetails: FC<{
     ),
     "Installation Path": <Value>{appInstallation.installationPath}</Value>,
     Description: <Value>{appInstallation.description}</Value>,
-    Status: (
+    Status: customInstallation ? (
+      <Text>custom application</Text>
+    ) : (
       <AppInstallationStatus
         appInstallation={appInstallation}
         desired={desiredAppVersion}


### PR DESCRIPTION
This PR improves the UX for installing custom (PHP + Node.js) applications. More precisely, this means:

- commands were moved from `mw app install {php,node}` to `mw app create {php,node}`, as it is more intuitive 
that the user does not "install an existing app", but instead "creates their own"
- "app list" and "app get" does not contain the version of the app template, because these are easily confused 
with the PHP or Node.js version that an app should use (fixes #43)
