### PR TITLE
Hide table during measuring dimensions

### DIFF
--- a/src/rendering/react/measure/MeasureContextProvider.tsx
+++ b/src/rendering/react/measure/MeasureContextProvider.tsx
@@ -1,5 +1,11 @@
 import { Box } from "ink";
-import { FC, PropsWithChildren, useRef } from "react";
+import {
+  FC,
+  PropsWithChildren,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { createMeasureContext, measureContext } from "./context.js";
 import { MeasureRenderer } from "./MeasureRenderer.js";
 
@@ -8,13 +14,24 @@ export const MeasureContextProvider: FC<PropsWithChildren> = (props) => {
 
   const context = useRef(createMeasureContext()).current;
 
+  const [isMeasuring, setIsMeasuring] = useState(true);
+
+  useLayoutEffect(() => {
+    setIsMeasuring(false);
+  }, []);
+
   return (
     <measureContext.Provider value={context}>
       <Box flexDirection="column" gap={1}>
         <Box>
           <MeasureRenderer />
         </Box>
-        <Box>{children}</Box>
+        <Box
+          height={isMeasuring ? 0 : undefined}
+          overflow={isMeasuring ? "hidden" : undefined}
+        >
+          {children}
+        </Box>
       </Box>
     </measureContext.Provider>
   );


### PR DESCRIPTION
This change hides the table output during measuring cell dimensions and therefore prevents the table from being re-rendered initially.