### PR TITLE
Unify JSON/YAML output of list views with the other commands + disable sorting&filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,8 +437,7 @@ Get all available dependencies
 
 ```
 USAGE
-  $ mw app dependency list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw app dependency list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -446,10 +445,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get all available dependencies
@@ -498,8 +495,8 @@ Get all available versions of a particular dependency
 
 ```
 USAGE
-  $ mw app dependency versions SYSTEMSOFTWARE [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [-o json|yaml|csv |  | ] [--sort <value>]
+  $ mw app dependency versions SYSTEMSOFTWARE [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ]
 
 ARGUMENTS
   SYSTEMSOFTWARE  name of the systemsoftware for which to list versions
@@ -510,10 +507,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get all available versions of a particular dependency
@@ -1426,8 +1421,8 @@ List installed apps in a project.
 
 ```
 USAGE
-  $ mw app list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw app list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -1437,10 +1432,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List installed apps in a project.
@@ -1680,8 +1673,8 @@ List Backups for a given Project.
 
 ```
 USAGE
-  $ mw backup list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw backup list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -1691,10 +1684,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List Backups for a given Project.
@@ -1715,8 +1706,8 @@ List backup schedules belonging to a given project.
 
 ```
 USAGE
-  $ mw backup schedule list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw backup schedule list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -1726,10 +1717,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List backup schedules belonging to a given project.
@@ -1790,8 +1779,7 @@ Get all conversation categories.
 
 ```
 USAGE
-  $ mw conversation categories [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw conversation categories [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -1799,10 +1787,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get all conversation categories.
@@ -1853,8 +1839,7 @@ Get all conversations the authenticated user has created or has access to.
 
 ```
 USAGE
-  $ mw conversation list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw conversation list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -1862,10 +1847,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get all conversations the authenticated user has created or has access to.
@@ -1951,8 +1934,8 @@ List CronjobExecutions belonging to a Cronjob.
 
 ```
 USAGE
-  $ mw cronjob execution list --cronjob-id <value> [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [-o json|yaml|csv |  | ] [--sort <value>]
+  $ mw cronjob execution list --cronjob-id <value> [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -1961,10 +1944,8 @@ FLAGS
       --columns=<value>     only show provided columns (comma-separated)
       --cronjob-id=<value>  (required) ID of the Cronjob for which to list CronjobExecutions for.
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List CronjobExecutions belonging to a Cronjob.
@@ -2029,8 +2010,8 @@ List Cronjobs belonging to a Project.
 
 ```
 USAGE
-  $ mw cronjob list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw cronjob list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -2040,10 +2021,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List Cronjobs belonging to a Project.
@@ -2064,8 +2043,7 @@ List available MySQL character sets and collations, optionally filtered by a MyS
 
 ```
 USAGE
-  $ mw database mysql charsets [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw database mysql charsets [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -2073,10 +2051,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List available MySQL character sets and collations, optionally filtered by a MySQLVersion.
@@ -2207,8 +2183,8 @@ List MySQLDatabases belonging to a Project.
 
 ```
 USAGE
-  $ mw database mysql list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw database mysql list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -2218,10 +2194,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List MySQLDatabases belonging to a Project.
@@ -2322,8 +2296,8 @@ List MySQL users belonging to a database.
 
 ```
 USAGE
-  $ mw database mysql user list --database-id <value> [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [-o json|yaml|csv |  | ] [--sort <value>]
+  $ mw database mysql user list --database-id <value> [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>      output in a more machine friendly format
@@ -2332,10 +2306,8 @@ FLAGS
       --columns=<value>      only show provided columns (comma-separated)
       --csv                  output is csv format [alias: --output=csv]
       --database-id=<value>  (required) ID of the MySQL database to list users for.
-      --filter=<value>       filter property by partial string matching, ex: name=foo
       --no-header            hide table header from output
       --no-truncate          do not truncate output to fit screen
-      --sort=<value>         property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List MySQL users belonging to a database.
@@ -2347,8 +2319,7 @@ List available MySQL versions.
 
 ```
 USAGE
-  $ mw database mysql versions [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw database mysql versions [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -2356,10 +2327,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List available MySQL versions.
@@ -2439,8 +2408,8 @@ List Redis databases belonging to a project.
 
 ```
 USAGE
-  $ mw database redis list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw database redis list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -2450,10 +2419,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List Redis databases belonging to a project.
@@ -2492,8 +2459,8 @@ List available Redis versions.
 
 ```
 USAGE
-  $ mw database redis versions [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw database redis versions [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -2503,10 +2470,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List available Redis versions.
@@ -2586,8 +2551,8 @@ List Domains belonging to a Project.
 
 ```
 USAGE
-  $ mw domain list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw domain list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -2597,10 +2562,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List Domains belonging to a Project.
@@ -2637,8 +2600,8 @@ List all domain ownerships of a project.
 
 ```
 USAGE
-  $ mw domain ownership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw domain ownership list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -2648,10 +2611,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all domain ownerships of a project.
@@ -2775,8 +2736,8 @@ List virtualhosts for a project.
 
 ```
 USAGE
-  $ mw domain virtualhost list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>] [-a]
+  $ mw domain virtualhost list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>] [-a]
 
 FLAGS
   -a, --all                 List all virtual hosts that you have access to, regardless of project
@@ -2787,10 +2748,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List virtualhosts for a project.
@@ -2972,8 +2931,8 @@ Get all mail addresses for a project ID
 
 ```
 USAGE
-  $ mw mail address list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw mail address list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -2983,10 +2942,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get all mail addresses for a project ID
@@ -3023,8 +2980,8 @@ Get all deliveryboxes by project ID
 
 ```
 USAGE
-  $ mw mail deliverybox list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw mail deliverybox list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -3034,10 +2991,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get all deliveryboxes by project ID
@@ -3132,8 +3087,8 @@ List all invites for an organization.
 
 ```
 USAGE
-  $ mw org invite list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-o <value>]
+  $ mw org invite list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-o
+    <value>]
 
 FLAGS
   -o, --org-id=<value>   ID or short ID of a org; this flag is optional if a default org is set in the context
@@ -3142,10 +3097,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all invites for an organization.
@@ -3163,8 +3116,7 @@ List all organization invites for the executing user.
 
 ```
 USAGE
-  $ mw org invite list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw org invite list-own [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -3172,10 +3124,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all organization invites for the executing user.
@@ -3211,8 +3161,7 @@ Get all organizations the authenticated user has access to.
 
 ```
 USAGE
-  $ mw org list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw org list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -3220,10 +3169,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get all organizations the authenticated user has access to.
@@ -3235,8 +3182,8 @@ List all memberships belonging to an organization.
 
 ```
 USAGE
-  $ mw org membership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-o <value>]
+  $ mw org membership list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-o
+    <value>]
 
 FLAGS
   -o, --org-id=<value>   ID or short ID of a org; this flag is optional if a default org is set in the context
@@ -3245,10 +3192,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all memberships belonging to an organization.
@@ -3266,8 +3211,7 @@ List all organization memberships for the executing user.
 
 ```
 USAGE
-  $ mw org membership list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw org membership list-own [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -3275,10 +3219,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all organization memberships for the executing user.
@@ -3444,8 +3386,8 @@ List Backups for a given Project.
 
 ```
 USAGE
-  $ mw project backup list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw project backup list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -3455,10 +3397,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List Backups for a given Project.
@@ -3479,8 +3419,8 @@ List backup schedules belonging to a given project.
 
 ```
 USAGE
-  $ mw project backupschedule list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw project backupschedule list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -3490,10 +3430,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List backup schedules belonging to a given project.
@@ -3569,8 +3507,8 @@ List CronjobExecutions belonging to a Cronjob.
 
 ```
 USAGE
-  $ mw project cronjob execution list --cronjob-id <value> [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [-o json|yaml|csv |  | ] [--sort <value>]
+  $ mw project cronjob execution list --cronjob-id <value> [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -3579,10 +3517,8 @@ FLAGS
       --columns=<value>     only show provided columns (comma-separated)
       --cronjob-id=<value>  (required) ID of the Cronjob for which to list CronjobExecutions for.
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List CronjobExecutions belonging to a Cronjob.
@@ -3647,8 +3583,8 @@ List Cronjobs belonging to a Project.
 
 ```
 USAGE
-  $ mw project cronjob list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw project cronjob list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -3658,10 +3594,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List Cronjobs belonging to a Project.
@@ -3765,8 +3699,8 @@ List all invites belonging to a project.
 
 ```
 USAGE
-  $ mw project invite list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw project invite list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -3776,10 +3710,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all invites belonging to a project.
@@ -3797,8 +3729,7 @@ List all project invites for the executing user.
 
 ```
 USAGE
-  $ mw project invite list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw project invite list-own [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -3806,10 +3737,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all project invites for the executing user.
@@ -3821,8 +3750,7 @@ List all projects that you have access to
 
 ```
 USAGE
-  $ mw project list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw project list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -3830,10 +3758,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all projects that you have access to
@@ -3888,8 +3814,8 @@ List all memberships for a Project.
 
 ```
 USAGE
-  $ mw project membership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw project membership list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -3899,10 +3825,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all memberships for a Project.
@@ -3920,8 +3844,8 @@ List ProjectMemberships belonging to the executing user.
 
 ```
 USAGE
-  $ mw project membership list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw project membership list-own [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |
+  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -3929,10 +3853,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List ProjectMemberships belonging to the executing user.
@@ -3944,8 +3866,8 @@ List all SFTP users for a project.
 
 ```
 USAGE
-  $ mw project sftp-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw project sftp-user list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -3955,10 +3877,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all SFTP users for a project.
@@ -3994,8 +3914,8 @@ List all SSH users for a project.
 
 ```
 USAGE
-  $ mw project ssh-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw project ssh-user list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -4005,10 +3925,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all SSH users for a project.
@@ -4063,8 +3981,7 @@ List servers for an organization or user.
 
 ```
 USAGE
-  $ mw server list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw server list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -4072,10 +3989,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List servers for an organization or user.
@@ -4087,8 +4002,8 @@ List all SFTP users for a project.
 
 ```
 USAGE
-  $ mw sftp-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw sftp-user list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -4098,10 +4013,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all SFTP users for a project.
@@ -4122,8 +4035,8 @@ List all SSH users for a project.
 
 ```
 USAGE
-  $ mw ssh-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
+  $ mw ssh-user list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ] [-p
+    <value>]
 
 FLAGS
   -o, --output=<option>     output in a more machine friendly format
@@ -4133,10 +4046,8 @@ FLAGS
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --csv                 output is csv format [alias: --output=csv]
-      --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all SSH users for a project.
@@ -4238,8 +4149,7 @@ List all API tokens of the user
 
 ```
 USAGE
-  $ mw user api-token list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw user api-token list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -4247,10 +4157,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all API tokens of the user
@@ -4326,8 +4234,7 @@ List all active sessions
 
 ```
 USAGE
-  $ mw user session list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw user session list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -4335,10 +4242,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   List all active sessions
@@ -4419,8 +4324,7 @@ Get your stored ssh keys
 
 ```
 USAGE
-  $ mw user ssh-key list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
-    json|yaml|csv |  | ] [--sort <value>]
+  $ mw user ssh-key list [--columns <value> | -x] [--no-header | [--csv | --no-truncate]] [-o json|yaml|csv |  | ]
 
 FLAGS
   -o, --output=<option>  output in a more machine friendly format
@@ -4428,10 +4332,8 @@ FLAGS
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
-      --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
   Get your stored ssh keys

--- a/README.md
+++ b/README.md
@@ -437,18 +437,18 @@ Get all available dependencies
 
 ```
 USAGE
-  $ mw app dependency list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw app dependency list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -499,20 +499,20 @@ Get all available versions of a particular dependency
 ```
 USAGE
   $ mw app dependency versions SYSTEMSOFTWARE [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    --no-truncate]] [-o json|yaml|csv |  | ] [--sort <value>]
 
 ARGUMENTS
   SYSTEMSOFTWARE  name of the systemsoftware for which to list versions
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -1426,10 +1426,12 @@ List installed apps in a project.
 
 ```
 USAGE
-  $ mw app list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw app list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -1438,8 +1440,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -1680,10 +1680,12 @@ List Backups for a given Project.
 
 ```
 USAGE
-  $ mw backup list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw backup list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -1692,8 +1694,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -1715,10 +1715,12 @@ List backup schedules belonging to a given project.
 
 ```
 USAGE
-  $ mw backup schedule list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw backup schedule list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -1727,8 +1729,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -1790,18 +1790,18 @@ Get all conversation categories.
 
 ```
 USAGE
-  $ mw conversation categories [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw conversation categories [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -1853,18 +1853,18 @@ Get all conversations the authenticated user has created or has access to.
 
 ```
 USAGE
-  $ mw conversation list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw conversation list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -1952,9 +1952,11 @@ List CronjobExecutions belonging to a Cronjob.
 ```
 USAGE
   $ mw cronjob execution list --cronjob-id <value> [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    --no-truncate]] [-o json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --cronjob-id=<value>  (required) ID of the Cronjob for which to list CronjobExecutions for.
@@ -1962,8 +1964,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2029,10 +2029,12 @@ List Cronjobs belonging to a Project.
 
 ```
 USAGE
-  $ mw cronjob list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw cronjob list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -2041,8 +2043,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2064,18 +2064,18 @@ List available MySQL character sets and collations, optionally filtered by a MyS
 
 ```
 USAGE
-  $ mw database mysql charsets [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw database mysql charsets [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2207,10 +2207,12 @@ List MySQLDatabases belonging to a Project.
 
 ```
 USAGE
-  $ mw database mysql list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw database mysql list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -2219,8 +2221,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2323,9 +2323,11 @@ List MySQL users belonging to a database.
 ```
 USAGE
   $ mw database mysql user list --database-id <value> [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    --no-truncate]] [-o json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>      output in a more machine friendly format
+                             <options: json|yaml|csv>
   -x, --extended             show extra columns
       --columns=<value>      only show provided columns (comma-separated)
       --csv                  output is csv format [alias: --output=csv]
@@ -2333,8 +2335,6 @@ FLAGS
       --filter=<value>       filter property by partial string matching, ex: name=foo
       --no-header            hide table header from output
       --no-truncate          do not truncate output to fit screen
-      --output=<option>      output in a more machine friendly format
-                             <options: csv|json|yaml>
       --sort=<value>         property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2347,18 +2347,18 @@ List available MySQL versions.
 
 ```
 USAGE
-  $ mw database mysql versions [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw database mysql versions [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2439,10 +2439,12 @@ List Redis databases belonging to a project.
 
 ```
 USAGE
-  $ mw database redis list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw database redis list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -2451,8 +2453,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2492,10 +2492,12 @@ List available Redis versions.
 
 ```
 USAGE
-  $ mw database redis versions [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw database redis versions [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -2504,8 +2506,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2586,10 +2586,12 @@ List Domains belonging to a Project.
 
 ```
 USAGE
-  $ mw domain list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw domain list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -2598,8 +2600,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2637,10 +2637,12 @@ List all domain ownerships of a project.
 
 ```
 USAGE
-  $ mw domain ownership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw domain ownership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -2649,8 +2651,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2775,11 +2775,13 @@ List virtualhosts for a project.
 
 ```
 USAGE
-  $ mw domain virtualhost list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>] [-a]
+  $ mw domain virtualhost list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>] [-a]
 
 FLAGS
   -a, --all                 List all virtual hosts that you have access to, regardless of project
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -2788,8 +2790,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -2972,10 +2972,12 @@ Get all mail addresses for a project ID
 
 ```
 USAGE
-  $ mw mail address list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw mail address list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -2984,8 +2986,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3023,10 +3023,12 @@ Get all deliveryboxes by project ID
 
 ```
 USAGE
-  $ mw mail deliverybox list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw mail deliverybox list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -3035,8 +3037,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3132,19 +3132,19 @@ List all invites for an organization.
 
 ```
 USAGE
-  $ mw org invite list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-o <value>]
+  $ mw org invite list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-o <value>]
 
 FLAGS
   -o, --org-id=<value>   ID or short ID of a org; this flag is optional if a default org is set in the context
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3163,18 +3163,18 @@ List all organization invites for the executing user.
 
 ```
 USAGE
-  $ mw org invite list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw org invite list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3211,18 +3211,18 @@ Get all organizations the authenticated user has access to.
 
 ```
 USAGE
-  $ mw org list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw org list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3235,19 +3235,19 @@ List all memberships belonging to an organization.
 
 ```
 USAGE
-  $ mw org membership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-o <value>]
+  $ mw org membership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-o <value>]
 
 FLAGS
   -o, --org-id=<value>   ID or short ID of a org; this flag is optional if a default org is set in the context
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3266,18 +3266,18 @@ List all organization memberships for the executing user.
 
 ```
 USAGE
-  $ mw org membership list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw org membership list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3444,10 +3444,12 @@ List Backups for a given Project.
 
 ```
 USAGE
-  $ mw project backup list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw project backup list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -3456,8 +3458,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3479,10 +3479,12 @@ List backup schedules belonging to a given project.
 
 ```
 USAGE
-  $ mw project backupschedule list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw project backupschedule list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -3491,8 +3493,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3570,9 +3570,11 @@ List CronjobExecutions belonging to a Cronjob.
 ```
 USAGE
   $ mw project cronjob execution list --cronjob-id <value> [--columns <value> | -x] [--filter <value>] [--no-header | [--csv |
-    --no-truncate]] [--output csv|json|yaml |  | ] [--sort <value>]
+    --no-truncate]] [-o json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -x, --extended            show extra columns
       --columns=<value>     only show provided columns (comma-separated)
       --cronjob-id=<value>  (required) ID of the Cronjob for which to list CronjobExecutions for.
@@ -3580,8 +3582,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3647,10 +3647,12 @@ List Cronjobs belonging to a Project.
 
 ```
 USAGE
-  $ mw project cronjob list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw project cronjob list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -3659,8 +3661,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3765,10 +3765,12 @@ List all invites belonging to a project.
 
 ```
 USAGE
-  $ mw project invite list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw project invite list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -3777,8 +3779,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3797,18 +3797,18 @@ List all project invites for the executing user.
 
 ```
 USAGE
-  $ mw project invite list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw project invite list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3821,18 +3821,18 @@ List all projects that you have access to
 
 ```
 USAGE
-  $ mw project list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw project list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3888,10 +3888,12 @@ List all memberships for a Project.
 
 ```
 USAGE
-  $ mw project membership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw project membership list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -3900,8 +3902,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3920,18 +3920,18 @@ List ProjectMemberships belonging to the executing user.
 
 ```
 USAGE
-  $ mw project membership list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw project membership list-own [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3944,10 +3944,12 @@ List all SFTP users for a project.
 
 ```
 USAGE
-  $ mw project sftp-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw project sftp-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -3956,8 +3958,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -3994,10 +3994,12 @@ List all SSH users for a project.
 
 ```
 USAGE
-  $ mw project ssh-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw project ssh-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -4006,8 +4008,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -4063,18 +4063,18 @@ List servers for an organization or user.
 
 ```
 USAGE
-  $ mw server list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw server list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -4087,10 +4087,12 @@ List all SFTP users for a project.
 
 ```
 USAGE
-  $ mw sftp-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw sftp-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -4099,8 +4101,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -4122,10 +4122,12 @@ List all SSH users for a project.
 
 ```
 USAGE
-  $ mw ssh-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>] [-p <value>]
+  $ mw ssh-user list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>] [-p <value>]
 
 FLAGS
+  -o, --output=<option>     output in a more machine friendly format
+                            <options: json|yaml|csv>
   -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the
                             context
   -x, --extended            show extra columns
@@ -4134,8 +4136,6 @@ FLAGS
       --filter=<value>      filter property by partial string matching, ex: name=foo
       --no-header           hide table header from output
       --no-truncate         do not truncate output to fit screen
-      --output=<option>     output in a more machine friendly format
-                            <options: csv|json|yaml>
       --sort=<value>        property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -4238,18 +4238,18 @@ List all API tokens of the user
 
 ```
 USAGE
-  $ mw user api-token list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw user api-token list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -4326,18 +4326,18 @@ List all active sessions
 
 ```
 USAGE
-  $ mw user session list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw user session list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION
@@ -4419,18 +4419,18 @@ Get your stored ssh keys
 
 ```
 USAGE
-  $ mw user ssh-key list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [--output
-    csv|json|yaml |  | ] [--sort <value>]
+  $ mw user ssh-key list [--columns <value> | -x] [--filter <value>] [--no-header | [--csv | --no-truncate]] [-o
+    json|yaml|csv |  | ] [--sort <value>]
 
 FLAGS
+  -o, --output=<option>  output in a more machine friendly format
+                         <options: json|yaml|csv>
   -x, --extended         show extra columns
       --columns=<value>  only show provided columns (comma-separated)
       --csv              output is csv format [alias: --output=csv]
       --filter=<value>   filter property by partial string matching, ex: name=foo
       --no-header        hide table header from output
       --no-truncate      do not truncate output to fit screen
-      --output=<option>  output in a more machine friendly format
-                         <options: csv|json|yaml>
       --sort=<value>     property to sort by (prepend '-' for descending)
 
 DESCRIPTION

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -36,6 +36,11 @@ export class ListFormatter {
   public static get flags(): FlagInput {
     return {
       ...ux.table.flags(),
+      output: {
+        ...ux.table.flags().output,
+        options: ["json", "yaml", "csv"],
+        char: "o",
+      },
     };
   }
 
@@ -45,6 +50,11 @@ export class ListFormatter {
     opts?: ListOptions,
   ): void {
     if (output.length === 0) {
+      return;
+    }
+
+    if (opts?.output === "json" || opts?.output === "yaml") {
+      PrinterFactory.build(opts.output).log(output);
       return;
     }
 

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -34,7 +34,12 @@ export class GetFormatter<T = unknown> {
 
 export class ListFormatter {
   public static get flags(): FlagInput {
-    const tableFlags = ux.table.flags();
+    const tableFlags: Partial<typeof ux.table.Flags> &
+      Pick<typeof ux.table.Flags, "output"> = ux.table.flags();
+
+    delete tableFlags.sort;
+    delete tableFlags.filter;
+
     return {
       ...tableFlags,
       output: {

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -34,10 +34,11 @@ export class GetFormatter<T = unknown> {
 
 export class ListFormatter {
   public static get flags(): FlagInput {
+    const tableFlags = ux.table.flags();
     return {
-      ...ux.table.flags(),
+      ...tableFlags,
       output: {
-        ...ux.table.flags().output,
+        ...tableFlags.output,
         options: ["json", "yaml", "csv"],
         char: "o",
       },
@@ -49,12 +50,12 @@ export class ListFormatter {
     columns: ListColumns<T>,
     opts?: ListOptions,
   ): void {
-    if (output.length === 0) {
+    if (opts?.output === "json" || opts?.output === "yaml") {
+      PrinterFactory.build(opts.output).log(output);
       return;
     }
 
-    if (opts?.output === "json" || opts?.output === "yaml") {
-      PrinterFactory.build(opts.output).log(output);
+    if (output.length === 0) {
       return;
     }
 


### PR DESCRIPTION
This PR unifies the behaviour of the `--output` flag of the `list` commands with that of the rest.

This includes:

- Support both `--output` and `-o` (all commands except `list` already support `-o`)
- When rendering `json` or `yaml` output, always use the underlying API types, and *not* the rendered table 
colums; this makes output consistent to `get` and other commands
- Disable the `--sort` and `--filter` arguments; as discussed in #58 and #59, these are unintuitive and do not at all behave as a reasonable user would expect. This is broken by design, since everything is done client-side and also breaks when using pagination. For this reason, this PR disables sorting and filtering until it can be implemented correctly at a later time.

Fixes #58
Fixes #59
Fixes #60