### PR TITLE
Add context (incl. short-id) support for app installation IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1784,12 +1784,13 @@ Set context values for the current project, org or server
 
 ```
 USAGE
-  $ mw context set [--project-id <value>] [--server-id <value>] [--org-id <value>]
+  $ mw context set [--project-id <value>] [--server-id <value>] [--org-id <value>] [--installation-id <value>]
 
 FLAGS
-  --org-id=<value>      ID or short ID of an organization
-  --project-id=<value>  ID or short ID of a project
-  --server-id=<value>   ID or short ID of a server
+  --installation-id=<value>  ID or short ID of an app installation
+  --org-id=<value>           ID or short ID of an organization
+  --project-id=<value>       ID or short ID of a project
+  --server-id=<value>        ID or short ID of a server
 
 DESCRIPTION
   Set context values for the current project, org or server
@@ -1936,12 +1937,14 @@ Create a new cron job
 
 ```
 USAGE
-  $ mw cronjob create --description <value> --interval <value> [-i <value>] [-q] [--disable] [--email <value>]
-    [--url <value> | --command <value>] [--interpreter <value>]
+  $ mw cronjob create --description <value> --interval <value> [-p <value>] [-i <value>] [-q] [--disable] [--email
+    <value>] [--url <value> | --command <value>] [--interpreter <value>]
 
 FLAGS
   -i, --installation-id=<value>  ID or short ID of an app installation; this flag is optional if a default app
                                  installation is set in the context
+  -p, --project-id=<value>       ID or short ID of a project; this flag is optional if a default project is set in the
+                                 context
   -q, --quiet                    suppress process output and only display a machine-readable summary.
       --command=<value>          Command to execute for the cron job; either this or `--url` is required.
       --description=<value>      (required) Description of the cron job
@@ -1956,9 +1959,14 @@ FLAG DESCRIPTIONS
 
     ID or short ID of an app installation; this flag is optional if a default app installation is set in the context
 
-    May contain a short ID or a full ID of an app installation; you can also use the "mw context set
+    May contain a short ID or a full ID of an app installation.; you can also use the "mw context set
     --installation-id=<VALUE>" command to persistently set a default app installation for all commands that accept this
     flag.
+
+  -p, --project-id=<value>  ID or short ID of a project; this flag is optional if a default project is set in the context
+
+    May contain a short ID or a full ID of a project; you can also use the "mw context set --project-id=<VALUE>" command
+    to persistently set a default project for all commands that accept this flag.
 
   -q, --quiet  suppress process output and only display a machine-readable summary.
 

--- a/src/ExtendedBaseCommand.tsx
+++ b/src/ExtendedBaseCommand.tsx
@@ -25,7 +25,7 @@ export abstract class ExtendedBaseCommand<
   }
 
   public async withAppInstallationId(
-    command: CommandType<"installation"> | "flag" | "arg",
+    command: CommandType<"installation" | "project"> | "flag" | "arg",
   ): Promise<string> {
     return withAppInstallationId(
       this.apiClient,

--- a/src/commands/context/set.ts
+++ b/src/commands/context/set.ts
@@ -6,6 +6,7 @@ import {
   normalizeProjectIdToUuid,
   normalizeServerIdToUuid,
 } from "../../Helpers.js";
+import { normalizeAppInstallationId } from "../../lib/app/flags.js";
 
 export class Set extends BaseCommand {
   static summary = "Set context values for the current project, org or server";
@@ -20,6 +21,10 @@ export class Set extends BaseCommand {
     }),
     "org-id": Flags.string({
       description: "ID or short ID of an organization",
+    }),
+    "installation-id": Flags.string({
+      description: "ID or short ID of an app installation",
+      aliases: ["app-id", "app-installation-id"],
     }),
   };
 
@@ -52,6 +57,16 @@ export class Set extends BaseCommand {
       );
       await ctx.setOrgId(orgId);
       this.log(`Set organization ID to ${orgId}`);
+    }
+
+    if (flags["installation-id"]) {
+      const installationId = await normalizeAppInstallationId(
+        this.apiClient,
+        (await ctx.projectId())?.value ?? "",
+        flags["installation-id"],
+      );
+      await ctx.setAppInstallationId(installationId);
+      this.log(`Set installation ID to ${installationId}`);
     }
   }
 }

--- a/src/lib/app/flags.tsx
+++ b/src/lib/app/flags.tsx
@@ -27,19 +27,26 @@ export const {
   withId: withAppInstallationId,
 } = makeProjectFlagSet("installation", "i", {
   displayName: "app installation",
-  normalize: async (apiClient, projectId, id): Promise<string> => {
-    if (isUuid(id)) {
-      return id;
-    }
-
-    const appInstallations = await apiClient.app.listAppinstallations({
-      projectId,
-    });
-    assertStatus(appInstallations, 200);
-
-    return appInstallations.data.find((inst) => inst.shortId === id)?.id ?? id;
-  },
+  normalize: normalizeAppInstallationId,
+  supportsContext: true,
 });
+
+export async function normalizeAppInstallationId(
+  apiClient: MittwaldAPIV2Client,
+  projectId: string,
+  id: string,
+): Promise<string> {
+  if (isUuid(id)) {
+    return id;
+  }
+
+  const appInstallations = await apiClient.app.listAppinstallations({
+    projectId,
+  });
+  assertStatus(appInstallations, 200);
+
+  return appInstallations.data.find((inst) => inst.shortId === id)?.id ?? id;
+}
 
 export type AvailableFlagName = keyof AvailableFlags;
 

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -79,8 +79,11 @@ export class Context {
   public setProjectId = (id: string) => this.setContextValue("project-id", id);
   public setServerId = (id: string) => this.setContextValue("server-id", id);
   public setOrgId = (id: string) => this.setContextValue("org-id", id);
+  public setAppInstallationId = (id: string) =>
+    this.setContextValue("installation-id", id);
 
   public projectId = () => this.getContextValue("project-id");
   public serverId = () => this.getContextValue("server-id");
   public orgId = () => this.getContextValue("org-id");
+  public appInstallationId = () => this.getContextValue("installation-id");
 }

--- a/src/lib/project/flags.ts
+++ b/src/lib/project/flags.ts
@@ -43,6 +43,7 @@ export function makeProjectFlagSet<TName extends ContextNames>(
     displayName = name,
     supportsContext = false,
   } = opts;
+  const article = displayName.match(/^[aeiou]/i) ? "an" : "a";
 
   const flagName: ContextKey<TName> = `${name}-id`;
   const flags = {
@@ -50,18 +51,30 @@ export function makeProjectFlagSet<TName extends ContextNames>(
     [flagName]: Flags.string({
       char,
       required: !supportsContext,
-      summary: `ID or ${shortIDName} of a ${displayName}`,
-      description: `May contain a ${shortIDName} or a full ID of a ${displayName}.`,
+      summary: `ID or ${shortIDName} of ${article} ${displayName}`,
+      description: `May contain a ${shortIDName} or a full ID of ${article} ${displayName}.`,
       default: undefined,
     }),
   } as ContextFlags<TName | "project">;
 
   const args = {
     [flagName]: Args.string({
-      description: `ID or ${shortIDName} of a ${displayName}`,
+      description: `ID or ${shortIDName} of ${article} ${displayName}`,
       required: !supportsContext,
     }),
   } as ContextArgs<TName | "project">;
+
+  if (supportsContext) {
+    flags[
+      flagName
+    ].summary += `; this flag is optional if a default ${displayName} is set in the context`;
+    flags[
+      flagName
+    ].description += `; you can also use the "<%= config.bin %> context set --${flagName}=<VALUE>" command to persistently set a default ${displayName} for all commands that accept this flag.`;
+    args[
+      flagName
+    ].description += `; this argument is optional if a default ${displayName} is set in the context`;
+  }
 
   const idFromArgsOrFlag = (
     flags: FlagOutput,

--- a/src/lib/project/flags.ts
+++ b/src/lib/project/flags.ts
@@ -29,6 +29,7 @@ export type ProjectFlagSetOpts = {
   normalize: SubNormalizeFn;
   shortIDName: string;
   displayName: string;
+  supportsContext: boolean;
 };
 
 export function makeProjectFlagSet<TName extends ContextNames>(
@@ -40,6 +41,7 @@ export function makeProjectFlagSet<TName extends ContextNames>(
     normalize = (_1, _2, id) => id,
     shortIDName = "short ID",
     displayName = name,
+    supportsContext = false,
   } = opts;
 
   const flagName: ContextKey<TName> = `${name}-id`;
@@ -47,7 +49,7 @@ export function makeProjectFlagSet<TName extends ContextNames>(
     ...projectFlags,
     [flagName]: Flags.string({
       char,
-      required: true,
+      required: !supportsContext,
       summary: `ID or ${shortIDName} of a ${displayName}`,
       description: `May contain a ${shortIDName} or a full ID of a ${displayName}.`,
       default: undefined,
@@ -57,7 +59,7 @@ export function makeProjectFlagSet<TName extends ContextNames>(
   const args = {
     [flagName]: Args.string({
       description: `ID or ${shortIDName} of a ${displayName}`,
-      required: true,
+      required: !supportsContext,
     }),
   } as ContextArgs<TName | "project">;
 

--- a/src/rendering/react/RenderBaseCommand.tsx
+++ b/src/rendering/react/RenderBaseCommand.tsx
@@ -77,7 +77,7 @@ export abstract class RenderBaseCommand<
   protected abstract render(): ReactNode;
 
   protected useAppInstallationId(
-    command: CommandType<"installation"> | "flag" | "arg",
+    command: CommandType<"installation" | "project"> | "flag" | "arg",
   ): string {
     return usePromise(() => this.withAppInstallationId(command), []);
   }


### PR DESCRIPTION
This change enables app installation IDs to be stored in the CLI context with `mw set context --installation-id` and also includes support for app short-IDs.