### PR TITLE
Add option to override SSH user via flag or env

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,17 +551,18 @@ Download the filesystem of an app within a project to your local machine
 
 ```
 USAGE
-  $ mw app download [INSTALLATION-ID] --target <value> [-q] [--dry-run] [--delete]
+  $ mw app download [INSTALLATION-ID] --target <value> [-q] [--ssh-user <value>] [--dry-run] [--delete]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context
 
 FLAGS
-  -q, --quiet           suppress process output and only display a machine-readable summary.
-      --delete          delete local files that are not present on the server
-      --dry-run         do not actually download the app installation
-      --target=<value>  (required) target directory to download the app installation to
+  -q, --quiet             suppress process output and only display a machine-readable summary.
+      --delete            delete local files that are not present on the server
+      --dry-run           do not actually download the app installation
+      --ssh-user=<value>  override the SSH user to connect with; if omitted, your own user will be used
+      --target=<value>    (required) target directory to download the app installation to
 
 DESCRIPTION
   Download the filesystem of an app within a project to your local machine
@@ -1479,16 +1480,17 @@ Connect to an app via SSH
 
 ```
 USAGE
-  $ mw app ssh [INSTALLATION-ID] [--cd] [--info] [--test]
+  $ mw app ssh [INSTALLATION-ID] [--ssh-user <value>] [--cd] [--info] [--test]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context
 
 FLAGS
-  --[no-]cd  change to installation path after connecting
-  --info     only print connection information, without actually connecting
-  --test     test connection and exit
+  --[no-]cd           change to installation path after connecting
+  --info              only print connection information, without actually connecting
+  --ssh-user=<value>  override the SSH user to connect with; if omitted, your own user will be used
+  --test              test connection and exit
 
 DESCRIPTION
   Connect to an app via SSH
@@ -2269,7 +2271,7 @@ Create a dump of a MySQL database
 
 ```
 USAGE
-  $ mw database mysql dump DATABASE-ID -o <value> [-q] [-p <value>] [--temporary-user] [--gzip]
+  $ mw database mysql dump DATABASE-ID -o <value> [-q] [-p <value>] [--ssh-user <value>] [--temporary-user] [--gzip]
 
 ARGUMENTS
   DATABASE-ID  The ID of the database (when a project context is set, you can also use the name)
@@ -2279,6 +2281,7 @@ FLAGS
   -p, --mysql-password=<value>  the password to use for the MySQL user (env: MYSQL_PWD)
   -q, --quiet                   suppress process output and only display a machine-readable summary.
       --gzip                    compress the dump with gzip
+      --ssh-user=<value>        override the SSH user to connect with; if omitted, your own user will be used
       --[no-]temporary-user     create a temporary user for the dump
 
 FLAG DESCRIPTIONS
@@ -2382,14 +2385,15 @@ Forward the TCP port of a MySQL database to a local port
 
 ```
 USAGE
-  $ mw database mysql port-forward DATABASE-ID [-q] [--port <value>]
+  $ mw database mysql port-forward DATABASE-ID [-q] [--ssh-user <value>] [--port <value>]
 
 ARGUMENTS
   DATABASE-ID  The ID of the database (when a project context is set, you can also use the name)
 
 FLAGS
-  -q, --quiet         suppress process output and only display a machine-readable summary.
-      --port=<value>  [default: 3306] The local TCP port to forward to
+  -q, --quiet             suppress process output and only display a machine-readable summary.
+      --port=<value>      [default: 3306] The local TCP port to forward to
+      --ssh-user=<value>  override the SSH user to connect with; if omitted, your own user will be used
 
 FLAG DESCRIPTIONS
   -q, --quiet  suppress process output and only display a machine-readable summary.

--- a/README.md
+++ b/README.md
@@ -572,6 +572,13 @@ FLAG DESCRIPTIONS
 
     This flag controls if you want to see the process output or only a summary. When using mw non-interactively (e.g. in
     scripts), you can use this flag to easily get the IDs of created resources for further processing.
+
+  --ssh-user=<value>  override the SSH user to connect with; if omitted, your own user will be used
+
+    This flag can be used to override the SSH user that is used for a connection; be default, your own personal user
+    will be used for this.
+
+    You can also set this value by setting the MITTWALD_SSH_USER environment variable.
 ```
 
 ## `mw app get [INSTALLATION-ID]`
@@ -1494,6 +1501,14 @@ FLAGS
 
 DESCRIPTION
   Connect to an app via SSH
+
+FLAG DESCRIPTIONS
+  --ssh-user=<value>  override the SSH user to connect with; if omitted, your own user will be used
+
+    This flag can be used to override the SSH user that is used for a connection; be default, your own personal user
+    will be used for this.
+
+    You can also set this value by setting the MITTWALD_SSH_USER environment variable.
 ```
 
 ## `mw app uninstall [INSTALLATION-ID]`
@@ -2309,6 +2324,13 @@ FLAG DESCRIPTIONS
     Compress the dump with gzip. This is useful for large databases, as it can significantly reduce the size of the
     dump.
 
+  --ssh-user=<value>  override the SSH user to connect with; if omitted, your own user will be used
+
+    This flag can be used to override the SSH user that is used for a connection; be default, your own personal user
+    will be used for this.
+
+    You can also set this value by setting the MITTWALD_SSH_USER environment variable.
+
   --[no-]temporary-user  create a temporary user for the dump
 
     Create a temporary user for the dump. This user will be deleted after the dump has been created. This is useful if
@@ -2400,6 +2422,13 @@ FLAG DESCRIPTIONS
 
     This flag controls if you want to see the process output or only a summary. When using mw non-interactively (e.g. in
     scripts), you can use this flag to easily get the IDs of created resources for further processing.
+
+  --ssh-user=<value>  override the SSH user to connect with; if omitted, your own user will be used
+
+    This flag can be used to override the SSH user that is used for a connection; be default, your own personal user
+    will be used for this.
+
+    You can also set this value by setting the MITTWALD_SSH_USER environment variable.
 ```
 
 ## `mw database mysql shell DATABASE-ID`

--- a/src/commands/app/download.tsx
+++ b/src/commands/app/download.tsx
@@ -10,6 +10,7 @@ import { ReactNode } from "react";
 import { spawn } from "child_process";
 import { hasBinary } from "../../lib/hasbin.js";
 import { getSSHConnectionForAppInstallation } from "../../lib/ssh/appinstall.js";
+import { sshConnectionFlags } from "../../lib/ssh/flags.js";
 
 export class Download extends ExecRenderBaseCommand<typeof Download, void> {
   static description =
@@ -19,6 +20,7 @@ export class Download extends ExecRenderBaseCommand<typeof Download, void> {
   };
   static flags = {
     ...processFlags,
+    ...sshConnectionFlags,
     "dry-run": Flags.boolean({
       description: "do not actually download the app installation",
       default: false,
@@ -36,7 +38,12 @@ export class Download extends ExecRenderBaseCommand<typeof Download, void> {
 
   protected async exec(): Promise<void> {
     const appInstallationId = await this.withAppInstallationId(Download);
-    const { "dry-run": dryRun, target, delete: deleteLocal } = this.flags;
+    const {
+      "dry-run": dryRun,
+      target,
+      delete: deleteLocal,
+      "ssh-user": sshUser,
+    } = this.flags;
 
     const p = makeProcessRenderer(this.flags, "Downloading app installation");
 
@@ -46,6 +53,7 @@ export class Download extends ExecRenderBaseCommand<typeof Download, void> {
         return getSSHConnectionForAppInstallation(
           this.apiClient,
           appInstallationId,
+          sshUser,
         );
       },
     );

--- a/src/commands/app/ssh.ts
+++ b/src/commands/app/ssh.ts
@@ -3,12 +3,14 @@ import { appInstallationArgs } from "../../lib/app/flags.js";
 import { Flags } from "@oclif/core";
 import { ExtendedBaseCommand } from "../../ExtendedBaseCommand.js";
 import { getSSHConnectionForAppInstallation } from "../../lib/ssh/appinstall.js";
+import { sshConnectionFlags } from "../../lib/ssh/flags.js";
 
 export default class Ssh extends ExtendedBaseCommand<typeof Ssh> {
   static description = "Connect to an app via SSH";
 
   static args = { ...appInstallationArgs };
   static flags = {
+    ...sshConnectionFlags,
     cd: Flags.boolean({
       summary: "change to installation path after connecting",
       default: true,
@@ -29,6 +31,7 @@ export default class Ssh extends ExtendedBaseCommand<typeof Ssh> {
     const { host, user, directory } = await getSSHConnectionForAppInstallation(
       this.apiClient,
       appInstallationId,
+      flags["ssh-user"],
     );
 
     if (flags.info) {

--- a/src/commands/database/mysql/dump.tsx
+++ b/src/commands/database/mysql/dump.tsx
@@ -20,6 +20,7 @@ import { randomBytes } from "crypto";
 import { executeViaSSH, RunCommand } from "../../../lib/ssh/exec.js";
 import assertSuccess from "../../../lib/assert_success.js";
 import shellEscape from "shell-escape";
+import { sshConnectionFlags } from "../../../lib/ssh/flags.js";
 
 export class Dump extends ExecRenderBaseCommand<
   typeof Dump,
@@ -29,6 +30,7 @@ export class Dump extends ExecRenderBaseCommand<
   static flags = {
     ...processFlags,
     ...mysqlConnectionFlags,
+    ...sshConnectionFlags,
     "temporary-user": Flags.boolean({
       summary: "create a temporary user for the dump",
       description:
@@ -106,6 +108,7 @@ export class Dump extends ExecRenderBaseCommand<
       () =>
         executeViaSSH(
           this.apiClient,
+          this.flags["ssh-user"],
           { projectId: connectionDetails.project.id },
           cmd,
           this.getOutputStream(),

--- a/src/commands/database/mysql/port-forward.tsx
+++ b/src/commands/database/mysql/port-forward.tsx
@@ -10,6 +10,7 @@ import { mysqlArgs, withMySQLId } from "../../../lib/database/mysql/flags.js";
 import { getConnectionDetails } from "../../../lib/database/mysql/connect.js";
 import { Value } from "../../../rendering/react/components/Value.js";
 import { Flags } from "@oclif/core";
+import { sshConnectionFlags } from "../../../lib/ssh/flags.js";
 
 export class PortForward extends ExecRenderBaseCommand<
   typeof PortForward,
@@ -18,6 +19,7 @@ export class PortForward extends ExecRenderBaseCommand<
   static summary = "Forward the TCP port of a MySQL database to a local port";
   static flags = {
     ...processFlags,
+    ...sshConnectionFlags,
     port: Flags.integer({
       summary: "The local TCP port to forward to",
       default: 3306,
@@ -40,6 +42,7 @@ export class PortForward extends ExecRenderBaseCommand<
     const { sshUser, sshHost, hostname, database } = await getConnectionDetails(
       this.apiClient,
       databaseId,
+      this.flags["ssh-user"],
       p,
     );
 

--- a/src/lib/ssh/appinstall.ts
+++ b/src/lib/ssh/appinstall.ts
@@ -5,6 +5,7 @@ import { SSHConnectionData } from "./types.js";
 export async function getSSHConnectionForAppInstallation(
   client: MittwaldAPIV2Client,
   appInstallationId: string,
+  sshUser: string | undefined,
 ): Promise<SSHConnectionData> {
   const appInstallationResponse = await client.app.getAppinstallation({
     appInstallationId,
@@ -22,12 +23,15 @@ export async function getSSHConnectionForAppInstallation(
 
   assertStatus(projectResponse, 200);
 
-  const userResponse = await client.user.getOwnAccount();
+  if (sshUser === undefined) {
+    const userResponse = await client.user.getOwnAccount();
 
-  assertStatus(userResponse, 200);
+    assertStatus(userResponse, 200);
+    sshUser = userResponse.data.email;
+  }
 
   const host = `ssh.${projectResponse.data.clusterID}.${projectResponse.data.clusterDomain}`;
-  const user = `${userResponse.data.email}@${appInstallationResponse.data.shortId}`;
+  const user = `${sshUser}@${appInstallationResponse.data.shortId}`;
   const directory = path.join(
     projectResponse.data.directories["Web"],
     appInstallationResponse.data.installationPath,

--- a/src/lib/ssh/exec.ts
+++ b/src/lib/ssh/exec.ts
@@ -12,11 +12,12 @@ export type RunCommand =
 
 export async function executeViaSSH(
   client: MittwaldAPIV2Client,
+  sshUser: string | undefined,
   target: RunTarget,
   command: RunCommand,
   output: NodeJS.WritableStream,
 ): Promise<void> {
-  const { user, host } = await connectionDataForTarget(client, target);
+  const { user, host } = await connectionDataForTarget(client, target, sshUser);
   const sshCommandArgs =
     "shell" in command
       ? ["bash", "-c", command.shell]
@@ -55,10 +56,15 @@ export async function executeViaSSH(
 async function connectionDataForTarget(
   client: MittwaldAPIV2Client,
   target: RunTarget,
+  sshUser: string | undefined,
 ): Promise<SSHConnectionData> {
   if ("appInstallationId" in target) {
-    return getSSHConnectionForAppInstallation(client, target.appInstallationId);
+    return getSSHConnectionForAppInstallation(
+      client,
+      target.appInstallationId,
+      sshUser,
+    );
   } else {
-    return getSSHConnectionForProject(client, target.projectId);
+    return getSSHConnectionForProject(client, target.projectId, sshUser);
   }
 }

--- a/src/lib/ssh/flags.ts
+++ b/src/lib/ssh/flags.ts
@@ -1,0 +1,11 @@
+import { Flags } from "@oclif/core";
+
+export const sshConnectionFlags = {
+  "ssh-user": Flags.string({
+    description:
+      "override the SSH user to connect with; if omitted, your own user will be used",
+    required: false,
+    default: undefined,
+    env: "MITTWALD_SSH_USER",
+  }),
+};

--- a/src/lib/ssh/flags.ts
+++ b/src/lib/ssh/flags.ts
@@ -2,8 +2,13 @@ import { Flags } from "@oclif/core";
 
 export const sshConnectionFlags = {
   "ssh-user": Flags.string({
-    description:
+    summary:
       "override the SSH user to connect with; if omitted, your own user will be used",
+    description:
+      "This flag can be used to override the SSH user that is used for a " +
+      "connection; be default, your own personal user will be used for this." +
+      "\n\n" +
+      "You can also set this value by setting the MITTWALD_SSH_USER environment variable.",
     required: false,
     default: undefined,
     env: "MITTWALD_SSH_USER",

--- a/src/lib/ssh/project.ts
+++ b/src/lib/ssh/project.ts
@@ -4,17 +4,21 @@ import { SSHConnectionData } from "./types.js";
 export async function getSSHConnectionForProject(
   client: MittwaldAPIV2Client,
   projectId: string,
+  sshUser: string | undefined,
 ): Promise<SSHConnectionData> {
   const projectResponse = await client.project.getProject({ projectId });
 
   assertStatus(projectResponse, 200);
 
-  const userResponse = await client.user.getOwnAccount();
+  if (sshUser === undefined) {
+    const userResponse = await client.user.getOwnAccount();
 
-  assertStatus(userResponse, 200);
+    assertStatus(userResponse, 200);
+    sshUser = userResponse.data.email;
+  }
 
   const host = `ssh.${projectResponse.data.clusterID}.${projectResponse.data.clusterDomain}`;
-  const user = `${userResponse.data.email}@${projectResponse.data.shortId}`;
+  const user = `${sshUser}@${projectResponse.data.shortId}`;
   const directory = projectResponse.data.directories["Web"];
 
   return {


### PR DESCRIPTION
This PR adds the option to override the SSH user that should be used for all commands that establish an SSH 
connection in the background.

This is useful in cases where you do not want to use your personal SSH user (for example, in an automation use 
case), but use a project-specific SSH user, instead.
