### PR TITLE
Interactively prompt for DDEV project type if undiscoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3264,19 +3264,23 @@ Initialize a new ddev project in the current directory.
 
 ```
 USAGE
-  $ mw ddev init [INSTALLATION-ID] [-q] [--override-type <value>] [--without-database | --database-id <value>]
-    [--project-name <value>] [--override-mittwald-plugin <value>]
+  $ mw ddev init [INSTALLATION-ID] [-q] [--override-type
+    backdrop|craftcms|django4|drupal6|drupal7|drupal|laravel|magento|magento2|php|python|shopware6|silverstripe|typo3|wo
+    rdpress|auto] [--without-database | --database-id <value>] [--project-name <value>] [--override-mittwald-plugin
+    <value>]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context
 
 FLAGS
-  -q, --quiet                  suppress process output and only display a machine-readable summary.
-      --database-id=<value>    ID of the application database
-      --override-type=<value>  [default: auto] Override the type of the generated DDEV configuration
-      --project-name=<value>   DDEV project name
-      --without-database       Create a DDEV project without a database
+  -q, --quiet                   suppress process output and only display a machine-readable summary.
+      --database-id=<value>     ID of the application database
+      --override-type=<option>  [default: auto] Override the type of the generated DDEV configuration
+                                <options: backdrop|craftcms|django4|drupal6|drupal7|drupal|laravel|magento|magento2|php|
+                                python|shopware6|silverstripe|typo3|wordpress|auto>
+      --project-name=<value>    DDEV project name
+      --without-database        Create a DDEV project without a database
 
 DEVELOPMENT FLAGS
   --override-mittwald-plugin=<value>  [default: mittwald/ddev] override the mittwald plugin
@@ -3316,7 +3320,9 @@ FLAG DESCRIPTIONS
     This flag allows you to override the mittwald plugin that should be installed by default; this is useful for testing
     purposes
 
-  --override-type=<value>  Override the type of the generated DDEV configuration
+  --override-type=backdrop|craftcms|django4|drupal6|drupal7|drupal|laravel|magento|magento2|php|python|shopware6|silverstripe|typo3|wordpress|auto
+
+    Override the type of the generated DDEV configuration
 
     The type of the generated DDEV configuration; this can be any of the documented DDEV project types, or 'auto' (which
     is also the default) for automatic discovery.
@@ -3339,16 +3345,20 @@ Generate a DDEV configuration YAML file for the current app.
 
 ```
 USAGE
-  $ mw ddev render-config [INSTALLATION-ID] [--override-type <value>] [--without-database | --database-id <value>]
+  $ mw ddev render-config [INSTALLATION-ID] [--override-type
+    backdrop|craftcms|django4|drupal6|drupal7|drupal|laravel|magento|magento2|php|python|shopware6|silverstripe|typo3|wo
+    rdpress|auto] [--without-database | --database-id <value>]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context
 
 FLAGS
-  --database-id=<value>    ID of the application database
-  --override-type=<value>  [default: auto] Override the type of the generated DDEV configuration
-  --without-database       Create a DDEV project without a database
+  --database-id=<value>     ID of the application database
+  --override-type=<option>  [default: auto] Override the type of the generated DDEV configuration
+                            <options: backdrop|craftcms|django4|drupal6|drupal7|drupal|laravel|magento|magento2|php|pyth
+                            on|shopware6|silverstripe|typo3|wordpress|auto>
+  --without-database        Create a DDEV project without a database
 
 DESCRIPTION
   Generate a DDEV configuration YAML file for the current app.
@@ -3364,7 +3374,9 @@ FLAG DESCRIPTIONS
     Setting a database ID (either automatically or manually) is required. To create a DDEV project without a database,
     set the --without-database flag.
 
-  --override-type=<value>  Override the type of the generated DDEV configuration
+  --override-type=backdrop|craftcms|django4|drupal6|drupal7|drupal|laravel|magento|magento2|php|python|shopware6|silverstripe|typo3|wordpress|auto
+
+    Override the type of the generated DDEV configuration
 
     The type of the generated DDEV configuration; this can be any of the documented DDEV project types, or 'auto' (which
     is also the default) for automatic discovery.

--- a/src/commands/ddev/init.tsx
+++ b/src/commands/ddev/init.tsx
@@ -27,6 +27,7 @@ import {
   assertDDEVIsInstalled,
   determineDDEVVersion,
 } from "../../lib/ddev/init_assert.js";
+import { determineProjectType } from "../../lib/ddev/init_projecttype.js";
 
 type AppInstallation = MittwaldAPIV2.Components.Schemas.AppAppInstallation;
 
@@ -74,6 +75,12 @@ export class Init extends ExecRenderBaseCommand<typeof Init, void> {
 
     const ddevVersion = await determineDDEVVersion(r);
     const appInstallation = await this.getAppInstallation(r, appInstallationId);
+    const projectType = await determineProjectType(
+      r,
+      this.apiClient,
+      appInstallation,
+      this.flags["override-type"],
+    );
     const databaseId = await determineDDEVDatabaseId(
       r,
       this.apiClient,
@@ -85,6 +92,7 @@ export class Init extends ExecRenderBaseCommand<typeof Init, void> {
       r,
       appInstallationId,
       databaseId,
+      projectType,
     );
     const projectName = await this.determineProjectName(r);
 
@@ -213,6 +221,7 @@ export class Init extends ExecRenderBaseCommand<typeof Init, void> {
     r: ProcessRenderer,
     appInstallationId: string,
     databaseId: string | undefined,
+    projectType: string,
   ) {
     const builder = new DDEVConfigBuilder(this.apiClient);
 
@@ -222,7 +231,7 @@ export class Init extends ExecRenderBaseCommand<typeof Init, void> {
         const config = await builder.build(
           appInstallationId,
           databaseId,
-          this.flags["override-type"],
+          projectType,
         );
         const configFile = path.join(".ddev", "config.mittwald.yaml");
 

--- a/src/commands/ddev/init.tsx
+++ b/src/commands/ddev/init.tsx
@@ -27,7 +27,10 @@ import {
   assertDDEVIsInstalled,
   determineDDEVVersion,
 } from "../../lib/ddev/init_assert.js";
-import { determineProjectType } from "../../lib/ddev/init_projecttype.js";
+import {
+  DDEVProjectType,
+  determineProjectType,
+} from "../../lib/ddev/init_projecttype.js";
 
 type AppInstallation = MittwaldAPIV2.Components.Schemas.AppAppInstallation;
 
@@ -79,7 +82,7 @@ export class Init extends ExecRenderBaseCommand<typeof Init, void> {
       r,
       this.apiClient,
       appInstallation,
-      this.flags["override-type"],
+      this.flags["override-type"] as DDEVProjectType | "auto",
     );
     const databaseId = await determineDDEVDatabaseId(
       r,

--- a/src/lib/ddev/flags.ts
+++ b/src/lib/ddev/flags.ts
@@ -1,5 +1,6 @@
 import { Flags } from "@oclif/core";
 import { InferredFlags } from "@oclif/core/lib/interfaces/index.js";
+import { knownDDEVProjectTypes } from "./init_projecttype.js";
 
 const ddevDatabaseFlags = {
   "database-id": Flags.string({
@@ -24,6 +25,7 @@ export const ddevFlags = {
   "override-type": Flags.string({
     summary: "Override the type of the generated DDEV configuration",
     default: "auto",
+    options: [...knownDDEVProjectTypes, "auto"] as const,
     description:
       "The type of the generated DDEV configuration; this can be any of the documented DDEV project types, or 'auto' (which is also the default) for automatic discovery." +
       "\n\n" +

--- a/src/lib/ddev/init_projecttype.tsx
+++ b/src/lib/ddev/init_projecttype.tsx
@@ -1,0 +1,145 @@
+import type { MittwaldAPIV2 } from "@mittwald/api-client";
+import { MittwaldAPIV2Client, assertStatus } from "@mittwald/api-client";
+import { typo3Installer } from "../../commands/app/install/typo3.js";
+import { wordpressInstaller } from "../../commands/app/install/wordpress.js";
+import { shopware6Installer } from "../../commands/app/install/shopware6.js";
+import { drupalInstaller } from "../../commands/app/install/drupal.js";
+import { ProcessRenderer } from "../../rendering/process/process.js";
+import { Value } from "../../rendering/react/components/Value.js";
+import { Text } from "ink";
+
+type AppInstallation = MittwaldAPIV2.Components.Schemas.AppAppInstallation;
+type AppVersion = MittwaldAPIV2.Components.Schemas.AppAppVersion;
+
+/**
+ * A list of all known DDEV project types. Shamelessly stolen from
+ * https://ddev.readthedocs.io/en/latest/users/configuration/config/#type
+ */
+const knownDDEVProjectTypes = [
+  "backdrop",
+  "craftcms",
+  "django4",
+  "drupal6",
+  "drupal7",
+  "drupal",
+  "laravel",
+  "magento",
+  "magento2",
+  "php",
+  "python",
+  "shopware6",
+  "silverstripe",
+  "typo3",
+  "wordpress",
+];
+
+async function getAppVersion(
+  client: MittwaldAPIV2Client,
+  appId: string,
+  appVersionId: string,
+): Promise<AppVersion> {
+  const r = await client.app.getAppversion({
+    appId,
+    appVersionId,
+  });
+
+  assertStatus(r, 200);
+  return r.data;
+}
+
+/**
+ * Determines the DDEV project type to use for the given app installation.
+ *
+ * This is done according to the following rules:
+ *
+ * 1. If an explicit override was specified (typically using the --override-type
+ *    flag), use that.
+ * 2. If the app installation is a known app type (e.g. TYPO3, WordPress, etc.),
+ *    use the corresponding DDEV project type.
+ * 3. Prompt the user to interactively select a DDEV project type.
+ */
+export async function determineProjectType(
+  r: ProcessRenderer,
+  client: MittwaldAPIV2Client,
+  inst: AppInstallation,
+  typeOverride: string,
+): Promise<string> {
+  if (typeOverride !== "auto") {
+    r.addInfo(<ProjectTypeInfoOverride type={typeOverride} />);
+    return typeOverride;
+  }
+
+  const determinedProjectType = await determineProjectTypeFromAppInstallation(
+    client,
+    inst,
+  );
+  if (determinedProjectType !== null) {
+    r.addInfo(<ProjectTypeInfoAuto type={determinedProjectType} />);
+    return determinedProjectType;
+  }
+
+  return await promptProjectTypeFromUser(r);
+}
+
+/**
+ * Interactively prompts the user to select a DDEV project type.
+ *
+ * The list of known project types is hardcoded in this module.
+ */
+async function promptProjectTypeFromUser(r: ProcessRenderer): Promise<string> {
+  return r.addSelect(
+    "select the DDEV project type",
+    knownDDEVProjectTypes.map((t) => ({ value: t, label: t })),
+  );
+}
+
+/**
+ * Determines the project type to use for the given app installation.
+ *
+ * In most cases, this is a simple mapping from known app IDs to DDEV project
+ * types. In some cases, we might need to know the specific (major) version of
+ * an app to determine the correct project type (for example, DDEV has separate
+ * project types for the different Drupal major versions).
+ */
+export async function determineProjectTypeFromAppInstallation(
+  client: MittwaldAPIV2Client,
+  inst: AppInstallation,
+): Promise<string | null> {
+  switch (inst.appId) {
+    case typo3Installer.appId:
+      return "typo3";
+    case wordpressInstaller.appId:
+      return "wordpress";
+    case shopware6Installer.appId:
+      return "shopware6";
+    case drupalInstaller.appId: {
+      const version = await getAppVersion(
+        client,
+        inst.appId,
+        inst.appVersion.desired,
+      );
+
+      const [major] = version.externalVersion.split(".");
+      return `drupal${major}`;
+    }
+    default:
+      return null;
+  }
+}
+
+function ProjectTypeInfoOverride({ type }: { type: string }) {
+  return (
+    <Text>
+      using DDEV project type: <Value>{type}</Value> (explicitly specified)
+    </Text>
+  );
+}
+
+function ProjectTypeInfoAuto({ type }: { type: string }) {
+  return (
+    <Text>
+      using DDEV project type: <Value>{type}</Value> (derived from app
+      installation)
+    </Text>
+  );
+}


### PR DESCRIPTION
This PR adds an interactive prompt when the DDEV project type cannot be determined automatically.

Fixes #434
