### PR TITLE
Discover additional DDEV config files correctly

### DIFF
--- a/src/lib/context_ddev.ts
+++ b/src/lib/context_ddev.ts
@@ -100,6 +100,6 @@ export class DDEVContextProvider implements ContextProvider {
 }
 
 async function findDDEVConfigFiles(dir: string): Promise<string[]> {
-  const configFilePattern = /^config\.*\.ya?ml$/;
+  const configFilePattern = /^config\..*\.ya?ml$/;
   return (await fs.readdir(dir)).filter((e) => configFilePattern.test(e));
 }


### PR DESCRIPTION
This PR fixes a bug which causes additional DDEV configuration files (like `.ddev/config.mittwald.yaml`) to not be discovered correctly.

https://xkcd.com/1171/