### PR TITLE
Make "mapData" implementation for list commands optional

### DIFF
--- a/src/commands/app/dependency/list.ts
+++ b/src/commands/app/dependency/list.ts
@@ -1,7 +1,10 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
-import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
+import {
+  ListBaseCommand,
+  SorterFunction,
+} from "../../../lib/basecommands/ListBaseCommand.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 
 type ResponseItem = Simplify<
@@ -19,18 +22,13 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
     ...ListBaseCommand.baseFlags,
   };
 
+  protected sorter: SorterFunction<ResponseItem> = (a, b) =>
+    a.tags[0].localeCompare(b.tags[0]) || a.name.localeCompare(b.name);
+
   public async getData(): Promise<Response> {
     return await this.apiClient.app.listSystemsoftwares({
       pathParameters: {},
     } as Parameters<typeof this.apiClient.app.listSystemsoftwares>[0]);
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    data.sort(
-      (a, b) =>
-        a.tags[0].localeCompare(b.tags[0]) || a.name.localeCompare(b.name),
-    );
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/app/dependency/list.ts
+++ b/src/commands/app/dependency/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import {
   ListBaseCommand,
   SorterFunction,

--- a/src/commands/app/dependency/versions.ts
+++ b/src/commands/app/dependency/versions.ts
@@ -1,7 +1,9 @@
 import { assertStatus, Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
+import {
+  ListBaseCommand,
+  SorterFunction,
+} from "../../../lib/basecommands/ListBaseCommand.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { SemVer } from "semver";
 import { Args } from "@oclif/core";
@@ -30,6 +32,9 @@ export class Versions extends ListBaseCommand<
     ...ListBaseCommand.baseFlags,
   };
 
+  sorter: SorterFunction<ResponseItem> = (a, b) =>
+    new SemVer(a.externalVersion).compare(b.externalVersion);
+
   public async getData(): Promise<Response> {
     const systemSoftwareName = this.args["systemsoftware"];
 
@@ -47,13 +52,6 @@ export class Versions extends ListBaseCommand<
     return await this.apiClient.app.listSystemsoftwareversions({
       systemSoftwareId: systemSoftware.id,
     } as Parameters<typeof this.apiClient.app.listSystemsoftwareversions>[0]);
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    data.sort((a, b) =>
-      new SemVer(a.externalVersion).compare(b.externalVersion),
-    );
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/app/download.tsx
+++ b/src/commands/app/download.tsx
@@ -12,10 +12,10 @@ import { spawnInProcess } from "../../rendering/process/process_exec.js";
 import { sshConnectionFlags } from "../../lib/resources/ssh/flags.js";
 import { sshUsageDocumentation } from "../../lib/resources/ssh/doc.js";
 import {
-  filterFileToRsyncFlagsIfPresent,
   appInstallationSyncFlags,
   appInstallationSyncFlagsToRsyncFlags,
   filterFileDocumentation,
+  filterFileToRsyncFlagsIfPresent,
 } from "../../lib/resources/app/sync.js";
 import { hasBinaryInPath } from "../../lib/util/fs/hasBinaryInPath.js";
 

--- a/src/commands/backup/list.ts
+++ b/src/commands/backup/list.ts
@@ -1,6 +1,5 @@
 import { Response, Simplify } from "@mittwald/api-client-commons";
 import type { MittwaldAPIV2 } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../lib/resources/project/flags.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";

--- a/src/commands/backup/list.ts
+++ b/src/commands/backup/list.ts
@@ -22,12 +22,6 @@ export class List extends ListBaseCommand<typeof List, ListItem, ListResponse> {
   static aliases = ["project:backup:list"];
   static deprecateAliases = true;
 
-  protected mapData(
-    data: SuccessfulResponse<ListResponse, 200>["data"],
-  ): ListItem[] | Promise<ListItem[]> {
-    return data;
-  }
-
   public async getData(): Promise<ListResponse> {
     const projectId = await this.withProjectId(List);
     return await this.apiClient.backup.listProjectBackups({

--- a/src/commands/backup/schedule/list.ts
+++ b/src/commands/backup/schedule/list.ts
@@ -42,10 +42,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
     });
   }
 
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
-  }
-
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {
     const { id, createdAt } = super.getColumns(data);
     return {

--- a/src/commands/backup/schedule/list.ts
+++ b/src/commands/backup/schedule/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import {

--- a/src/commands/conversation/categories.ts
+++ b/src/commands/conversation/categories.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 

--- a/src/commands/conversation/categories.ts
+++ b/src/commands/conversation/categories.ts
@@ -23,12 +23,8 @@ export default class Categories extends ListBaseCommand<
     ...ListBaseCommand.baseFlags,
   };
 
-  public async getData(): Promise<Response> {
-    return await this.apiClient.conversation.listCategories();
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
+  public getData(): Promise<Response> {
+    return this.apiClient.conversation.listCategories();
   }
 
   protected getColumns(): ListColumns<ResponseItem> {

--- a/src/commands/conversation/list.ts
+++ b/src/commands/conversation/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
 import { formatRelativeDate } from "../../rendering/textformat/formatDate.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";

--- a/src/commands/conversation/list.ts
+++ b/src/commands/conversation/list.ts
@@ -29,10 +29,6 @@ export default class List extends ListBaseCommand<
     return await this.apiClient.conversation.listConversations();
   }
 
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
-  }
-
   protected getColumns(): ListColumns<ResponseItem> {
     return {
       conversationId: {

--- a/src/commands/cronjob/execution/list.ts
+++ b/src/commands/cronjob/execution/list.ts
@@ -35,10 +35,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
     return await this.apiClient.cronjob.listExecutions({ cronjobId });
   }
 
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
-  }
-
   protected getColumns(): ListColumns<ResponseItem> {
     return {
       id: {},

--- a/src/commands/cronjob/execution/list.ts
+++ b/src/commands/cronjob/execution/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import { Flags } from "@oclif/core";

--- a/src/commands/cronjob/list.ts
+++ b/src/commands/cronjob/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../lib/resources/project/flags.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
@@ -29,12 +28,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
   public async getData(): Promise<Response> {
     const projectId = await this.withProjectId(List);
     return await this.apiClient.cronjob.listCronjobs({ projectId });
-  }
-
-  protected mapData(
-    data: SuccessfulResponse<Response, 200>["data"],
-  ): ResponseItem[] | Promise<ResponseItem[]> {
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/database/mysql/charsets.ts
+++ b/src/commands/database/mysql/charsets.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 

--- a/src/commands/database/mysql/charsets.ts
+++ b/src/commands/database/mysql/charsets.ts
@@ -24,13 +24,11 @@ export class Charsets extends ListBaseCommand<
     ...ListBaseCommand.baseFlags,
   };
 
+  protected sorter = (a: ResponseItem, b: ResponseItem) =>
+    a.name.localeCompare(b.name);
+
   public async getData(): Promise<Response> {
     return await this.apiClient.database.listMysqlCharsets({});
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    data.sort((a, b) => a.name.localeCompare(b.name));
-    return data;
   }
 
   protected getColumns(): ListColumns<ResponseItem> {

--- a/src/commands/database/mysql/list.ts
+++ b/src/commands/database/mysql/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../../lib/resources/project/flags.js";
@@ -26,10 +25,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
     return await this.apiClient.database.listMysqlDatabases({
       projectId,
     });
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(ignoredData: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/database/mysql/user/list.ts
+++ b/src/commands/database/mysql/user/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../../../lib/basecommands/ListBaseCommand.js";
 import { Flags } from "@oclif/core";
 import { ListColumns } from "../../../../rendering/formatter/ListFormatter.js";
@@ -28,10 +27,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
     return await this.apiClient.database.listMysqlUsers({
       mysqlDatabaseId: this.flags["database-id"],
     });
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/database/mysql/versions.ts
+++ b/src/commands/database/mysql/versions.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 
@@ -25,10 +24,6 @@ export class Versions extends ListBaseCommand<
 
   public async getData(): Promise<Response> {
     return await this.apiClient.database.listMysqlVersions({});
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(): ListColumns<ResponseItem> {

--- a/src/commands/database/redis/list.ts
+++ b/src/commands/database/redis/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../../lib/resources/project/flags.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
@@ -24,10 +23,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
   public async getData(): Promise<Response> {
     const projectId = await this.withProjectId(List);
     return await this.apiClient.database.listRedisDatabases({ projectId });
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/database/redis/versions.ts
+++ b/src/commands/database/redis/versions.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../../lib/resources/project/flags.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
@@ -30,10 +29,6 @@ export default class Versions extends ListBaseCommand<
     return await this.apiClient.database.listRedisVersions({
       queryParameters: { projectId },
     });
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(): ListColumns<ResponseItem> {

--- a/src/commands/domain/dnszone/list.ts
+++ b/src/commands/domain/dnszone/list.ts
@@ -2,7 +2,6 @@ import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { projectFlags } from "../../../lib/resources/project/flags.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import { Simplify } from "@mittwald/api-client-commons";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import {
   isCustomARecord,
@@ -36,12 +35,6 @@ export default class List extends ListBaseCommand<
   public async getData(): Promise<Response> {
     const projectId = await this.withProjectId(List);
     return this.apiClient.domain.dnsListDnsZones({ projectId });
-  }
-
-  protected mapData(
-    data: SuccessfulResponse<Response, 200>["data"],
-  ): ResponseItem[] | Promise<ResponseItem[]> {
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/domain/list.ts
+++ b/src/commands/domain/list.ts
@@ -2,7 +2,6 @@ import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../lib/resources/project/flags.js";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
 
 type ResponseItem = Simplify<
@@ -26,12 +25,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
     return this.apiClient.domain.listDomains({
       queryParameters: { projectId },
     });
-  }
-
-  protected mapData(
-    data: SuccessfulResponse<Response, 200>["data"],
-  ): ResponseItem[] | Promise<ResponseItem[]> {
-    return data;
   }
 
   protected getColumns(): ListColumns<ResponseItem> {

--- a/src/commands/domain/virtualhost/list.ts
+++ b/src/commands/domain/virtualhost/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import { Flags } from "@oclif/core";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
@@ -38,12 +37,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
     return await this.apiClient.domain.ingressListIngresses({
       queryParameters: { projectId },
     });
-  }
-
-  protected mapData(
-    data: SuccessfulResponse<Response, 200>["data"],
-  ): ResponseItem[] | Promise<ResponseItem[]> {
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/mail/address/create.tsx
+++ b/src/commands/mail/address/create.tsx
@@ -14,6 +14,7 @@ import * as crypto from "crypto";
 import { Value } from "../../../rendering/react/components/Value.js";
 import { FlagInput, OutputFlags } from "@oclif/core/lib/interfaces/parser.js";
 import ByteQuantity from "../../../lib/units/ByteQuantity.js";
+
 type CreateResult = {
   addressId: string;
   generatedPassword: string | null;

--- a/src/commands/mail/address/list.ts
+++ b/src/commands/mail/address/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { formatRelativeDate } from "../../../rendering/textformat/formatDate.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
@@ -27,10 +26,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
   public async getData(): Promise<Response> {
     const projectId = await this.withProjectId(List);
     return this.apiClient.mail.listMailAddresses({ projectId });
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/mail/deliverybox/list.ts
+++ b/src/commands/mail/deliverybox/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { formatRelativeDate } from "../../../rendering/textformat/formatDate.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
@@ -27,10 +26,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
   public async getData(): Promise<Response> {
     const projectId = await this.withProjectId(List);
     return this.apiClient.mail.listDeliveryBoxes({ projectId });
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 
@@ -32,10 +31,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
 
   protected mapParams(input: PathParams): Promise<PathParams> | PathParams {
     return input;
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/project/invite/list-own.ts
+++ b/src/commands/project/invite/list-own.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { formatRelativeDate } from "../../../rendering/textformat/formatDate.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
@@ -26,10 +25,6 @@ export default class List extends ListBaseCommand<
 
   public async getData(): Promise<Response> {
     return await this.apiClient.project.listProjectInvites();
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(): ListColumns<ResponseItem> {

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -5,7 +5,6 @@ import {
   MittwaldAPIV2Client,
   MittwaldAPIV2Client as MittwaldAPIClient,
 } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 
 type ProjectResponse = Awaited<
@@ -33,12 +32,6 @@ export class List extends ListBaseCommand<
 
   public async getData(): Promise<Response> {
     return await this.apiClient.project.listProjects();
-  }
-
-  protected mapData(
-    data: SuccessfulResponse<ProjectResponse, 200>["data"],
-  ): ProjectResponseItem[] {
-    return data;
   }
 
   protected getColumns(

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -1,15 +1,8 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
-import {
-  MittwaldAPIV2,
-  MittwaldAPIV2Client,
-  MittwaldAPIV2Client as MittwaldAPIClient,
-} from "@mittwald/api-client";
+import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 
-type ProjectResponse = Awaited<
-  ReturnType<MittwaldAPIClient["project"]["listProjects"]>
->;
 type ProjectResponseItem = Simplify<
   MittwaldAPIV2.Paths.V2Projects.Get.Responses.$200.Content.ApplicationJson[number]
 >;

--- a/src/commands/project/membership/list-own.ts
+++ b/src/commands/project/membership/list-own.ts
@@ -1,9 +1,9 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { formatRelativeDate } from "../../../rendering/textformat/formatDate.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
+import ListDateColumnFormatter from "../../../rendering/formatter/ListDateColumnFormatter.js";
 
 type ResponseItem = Simplify<
   MittwaldAPIV2.Paths.V2ProjectMemberships.Get.Responses.$200.Content.ApplicationJson[number]
@@ -29,28 +29,22 @@ export default class ListOwn extends ListBaseCommand<
     return await this.apiClient.project.listProjectMemberships();
   }
 
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
-  }
-
   protected getColumns(): ListColumns<ResponseItem> {
+    const dateColumnBuilder = new ListDateColumnFormatter(this.flags);
+    const expires = dateColumnBuilder.buildColumn({
+      header: "Expires",
+      column: "expiresAt",
+      fallback: "never",
+      extended: true,
+    });
+
     return {
       id: {
         header: "ID",
         minWidth: 36,
         extended: true,
       },
-      expires: {
-        header: "Expires",
-        extended: true,
-        get: (row) => {
-          if (!row.expiresAt) {
-            return "never";
-          }
-
-          return formatRelativeDate(new Date(row.expiresAt));
-        },
-      },
+      expires,
       projectId: { header: "Project Id" },
       role: { header: "Role" },
     };

--- a/src/commands/project/membership/list-own.ts
+++ b/src/commands/project/membership/list-own.ts
@@ -1,7 +1,6 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
-import { formatRelativeDate } from "../../../rendering/textformat/formatDate.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import ListDateColumnFormatter from "../../../rendering/formatter/ListDateColumnFormatter.js";
 

--- a/src/commands/server/list.ts
+++ b/src/commands/server/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 
@@ -25,10 +24,6 @@ export default class List extends ListBaseCommand<
 
   public async getData(): Promise<Response> {
     return await this.apiClient.project.listServers();
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(ignoredData: ResponseItem[]): ListColumns<ResponseItem> {

--- a/src/commands/sftp-user/list.ts
+++ b/src/commands/sftp-user/list.ts
@@ -1,13 +1,9 @@
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { Simplify } from "@mittwald/api-client-commons";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../lib/resources/project/flags.js";
 
-type SftpUserResponse = Awaited<
-  ReturnType<MittwaldAPIV2Client["sshsftpUser"]["sftpUserListSftpUsers"]>
->;
 type SftpUserResponseItem = Simplify<
   MittwaldAPIV2.Paths.V2ProjectsProjectIdSftpUsers.Get.Responses.$200.Content.ApplicationJson[number]
 >;
@@ -36,12 +32,6 @@ export default class List extends ListBaseCommand<
     return await this.apiClient.sshsftpUser.sftpUserListSftpUsers({
       projectId,
     });
-  }
-
-  protected mapData(
-    data: SuccessfulResponse<SftpUserResponse, 200>["data"],
-  ): SftpUserResponseItem[] {
-    return data;
   }
 
   protected getColumns(

--- a/src/commands/ssh-user/list.ts
+++ b/src/commands/ssh-user/list.ts
@@ -1,13 +1,9 @@
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { Simplify } from "@mittwald/api-client-commons";
-import { SuccessfulResponse } from "../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../lib/resources/project/flags.js";
 
-type SshUserResponse = Awaited<
-  ReturnType<MittwaldAPIV2Client["sshsftpUser"]["sftpUserListSftpUsers"]>
->;
 type SshUserResponseItem = Simplify<
   MittwaldAPIV2.Paths.V2ProjectsProjectIdSftpUsers.Get.Responses.$200.Content.ApplicationJson[number]
 >;
@@ -34,12 +30,6 @@ export class List extends ListBaseCommand<
   public async getData(): Promise<Response> {
     const projectId = await this.withProjectId(List);
     return await this.apiClient.sshsftpUser.sshUserListSshUsers({ projectId });
-  }
-
-  protected mapData(
-    data: SuccessfulResponse<SshUserResponse, 200>["data"],
-  ): SshUserResponseItem[] {
-    return data;
   }
 
   protected getColumns(

--- a/src/commands/user/api-token/list.ts
+++ b/src/commands/user/api-token/list.ts
@@ -1,6 +1,5 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { SuccessfulResponse } from "../../../lib/apiutil/SuccessfulResponse.js";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 
@@ -27,10 +26,6 @@ export default class List extends ListBaseCommand<
 
   public async getData(): Promise<Response> {
     return await this.apiClient.user.listApiTokens();
-  }
-
-  protected mapData(data: SuccessfulResponse<Response, 200>["data"]) {
-    return data;
   }
 
   protected getColumns(): ListColumns<ResponseItem> {

--- a/src/commands/user/session/list.ts
+++ b/src/commands/user/session/list.ts
@@ -1,7 +1,6 @@
 import { Simplify } from "@mittwald/api-client-commons";
 import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { ListColumns } from "../../../rendering/formatter/ListFormatter.js";
-import { formatRelativeDate } from "../../../rendering/textformat/formatDate.js";
 import { ListBaseCommand } from "../../../lib/basecommands/ListBaseCommand.js";
 import ListDateColumnFormatter from "../../../rendering/formatter/ListDateColumnFormatter.js";
 

--- a/src/lib/basecommands/ListBaseCommand.ts
+++ b/src/lib/basecommands/ListBaseCommand.ts
@@ -31,6 +31,7 @@ export abstract class ListBaseCommand<
   };
 
   protected formatter: ListFormatter = new ListFormatter();
+  protected sorter?: (a: TItem, b: TItem) => number;
 
   public async init(): Promise<void> {
     await super.init();
@@ -59,6 +60,10 @@ export abstract class ListBaseCommand<
   protected mapData(
     data: SuccessfulResponse<TAPIResponse, 200>["data"],
   ): TItem[] | Promise<TItem[]> {
+    if (this.sorter !== undefined) {
+      (data as TItem[]).sort(this.sorter);
+    }
+
     return data as TItem[];
   }
 

--- a/src/lib/basecommands/ListBaseCommand.ts
+++ b/src/lib/basecommands/ListBaseCommand.ts
@@ -56,9 +56,11 @@ export abstract class ListBaseCommand<
 
   protected abstract getData(): Promise<TAPIResponse>;
 
-  protected abstract mapData(
+  protected mapData(
     data: SuccessfulResponse<TAPIResponse, 200>["data"],
-  ): TItem[] | Promise<TItem[]>;
+  ): TItem[] | Promise<TItem[]> {
+    return data as TItem[];
+  }
 
   protected getColumns(
     data: TItem[],

--- a/src/lib/basecommands/ListBaseCommand.ts
+++ b/src/lib/basecommands/ListBaseCommand.ts
@@ -21,6 +21,8 @@ export type ColumnOpts<TItem> = {
   outputFormat?: string;
 };
 
+export type SorterFunction<TItem> = (a: TItem, b: TItem) => number;
+
 export abstract class ListBaseCommand<
   T extends typeof BaseCommand,
   TItem extends Record<string, unknown>,
@@ -31,7 +33,7 @@ export abstract class ListBaseCommand<
   };
 
   protected formatter: ListFormatter = new ListFormatter();
-  protected sorter?: (a: TItem, b: TItem) => number;
+  protected sorter?: SorterFunction<TItem>;
 
   public async init(): Promise<void> {
     await super.init();

--- a/src/rendering/formatter/ListDateColumnFormatter.ts
+++ b/src/rendering/formatter/ListDateColumnFormatter.ts
@@ -39,13 +39,16 @@ export default class ListDateColumnFormatter {
     header = "Created at",
     fallback = "unknown",
     column = "createdAt" as const,
+    extended = false,
   }: {
     header?: string;
     fallback?: string;
     column?: TColumnName | "createdAt";
+    extended?: boolean;
   } = {}): Partial<Column<Record<string, unknown>>> {
     return {
       header,
+      extended,
       get: (row) =>
         row[column] ? this.renderDate(new Date(`${row[column]}`)) : fallback,
     };


### PR DESCRIPTION
- **Provide a default implementation for ListBaseCommand.mapData**
- **Add option to provide a sorter if desired**
- **Remove unnecessary implementations of mapData**
