### PR TITLE
Add option to only up/download a subdirectory of an app installation

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -382,6 +382,15 @@ DESCRIPTION
   rsync. Have a look at https://manpages.ubuntu.com/manpages/noble/en/man1/rsync.1.html#filter%20rules for more
   information on how to write filter rules.
 
+EXAMPLES
+  Download entire app to current working directory
+
+    $ mw app download .
+
+  Download only shared dir from a deployer-managed app
+
+    $ mw app download --remote-sub-directory=shared .
+
 FLAG DESCRIPTIONS
   -q, --quiet  suppress process output and only display a machine-readable summary.
 
@@ -392,7 +401,8 @@ FLAG DESCRIPTIONS
 
     This is particularly useful when you only want to download a specific sub-directory of the app installation, for
     example when you are using a deployment tool that manages the app installation directory itself, and you only want
-    to download exempt files, like environment specific configuration files or user data.
+    to download exempt files, like environment specific configuration files or user data. For example, if you want to
+    download from "/html/my-app-XXXXX/config", set "--remote-sub-directory=config".
 
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
 
@@ -2046,7 +2056,8 @@ FLAG DESCRIPTIONS
 
     This is particularly useful when you only want to upload a specific sub-directory of the app installation, for
     example when you are using a deployment tool that manages the app installation directory itself, and you only want
-    to upload exempt files, like environment specific configuration files or user data.
+    to upload exempt files, like environment specific configuration files or user data. For example, if you want to
+    upload to "/html/my-app-XXXXX/config", set "--remote-sub-directory=config".
 
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
 

--- a/docs/app.md
+++ b/docs/app.md
@@ -345,19 +345,19 @@ Download the filesystem of an app within a project to your local machine
 ```
 USAGE
   $ mw app download [INSTALLATION-ID] --target <value> [-q] [--ssh-user <value>] [--ssh-identity-file <value>]
-    [--exclude <value>...] [--dry-run] [--delete] [--sub-directory <value>]
+    [--exclude <value>...] [--dry-run] [--delete] [--remote-sub-directory <value>]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context.
 
 FLAGS
-  -q, --quiet                  suppress process output and only display a machine-readable summary.
-      --delete                 delete local files that are not present on the server
-      --dry-run                do not actually download the app installation
-      --exclude=<value>...     [default: ] exclude files matching the given pattern
-      --sub-directory=<value>  specify a sub-directory within the app installation to download
-      --target=<value>         (required) target directory to download the app installation to
+  -q, --quiet                         suppress process output and only display a machine-readable summary.
+      --delete                        delete local files that are not present on the server
+      --dry-run                       do not actually download the app installation
+      --exclude=<value>...            [default: ] exclude files matching the given pattern
+      --remote-sub-directory=<value>  specify a sub-directory within the app installation to download
+      --target=<value>                (required) target directory to download the app installation to
 
 SSH CONNECTION FLAGS
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
@@ -388,6 +388,12 @@ FLAG DESCRIPTIONS
     This flag controls if you want to see the process output or only a summary. When using mw non-interactively (e.g. in
     scripts), you can use this flag to easily get the IDs of created resources for further processing.
 
+  --remote-sub-directory=<value>  specify a sub-directory within the app installation to download
+
+    This is particularly useful when you only want to download a specific sub-directory of the app installation, for
+    example when you are using a deployment tool that manages the app installation directory itself, and you only want
+    to download exempt files, like environment specific configuration files or user data.
+
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
 
     The SSH identity file to use for the connection. This file should contain an SSH private key and will be used to
@@ -401,12 +407,6 @@ FLAG DESCRIPTIONS
     will be used for this.
 
     You can also set this value by setting the MITTWALD_SSH_USER environment variable.
-
-  --sub-directory=<value>  specify a sub-directory within the app installation to download
-
-    This is particularly useful when you only want to download a specific sub-directory of the app installation, for
-    example when you are using a deployment tool that manages the app installation directory itself, and you only want
-    to download exempt files, like environment specific configuration files or user data.
 ```
 
 ## `mw app get [INSTALLATION-ID]`
@@ -1996,19 +1996,19 @@ Upload the filesystem of an app to a project
 ```
 USAGE
   $ mw app upload [INSTALLATION-ID] --source <value> [-q] [--ssh-user <value>] [--ssh-identity-file <value>]
-    [--exclude <value>...] [--dry-run] [--delete] [--sub-directory <value>]
+    [--exclude <value>...] [--dry-run] [--delete] [--remote-sub-directory <value>]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context.
 
 FLAGS
-  -q, --quiet                  suppress process output and only display a machine-readable summary.
-      --delete                 delete remote files that are not present locally
-      --dry-run                do not actually upload the app installation
-      --exclude=<value>...     [default: ] exclude files matching the given pattern
-      --source=<value>         (required) source directory from which to upload the app installation
-      --sub-directory=<value>  specify a sub-directory within the app installation to upload
+  -q, --quiet                         suppress process output and only display a machine-readable summary.
+      --delete                        delete remote files that are not present locally
+      --dry-run                       do not actually upload the app installation
+      --exclude=<value>...            [default: ] exclude files matching the given pattern
+      --remote-sub-directory=<value>  specify a sub-directory within the app installation to upload
+      --source=<value>                (required) source directory from which to upload the app installation
 
 SSH CONNECTION FLAGS
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
@@ -2042,6 +2042,12 @@ FLAG DESCRIPTIONS
     This flag controls if you want to see the process output or only a summary. When using mw non-interactively (e.g. in
     scripts), you can use this flag to easily get the IDs of created resources for further processing.
 
+  --remote-sub-directory=<value>  specify a sub-directory within the app installation to upload
+
+    This is particularly useful when you only want to upload a specific sub-directory of the app installation, for
+    example when you are using a deployment tool that manages the app installation directory itself, and you only want
+    to upload exempt files, like environment specific configuration files or user data.
+
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
 
     The SSH identity file to use for the connection. This file should contain an SSH private key and will be used to
@@ -2055,12 +2061,6 @@ FLAG DESCRIPTIONS
     will be used for this.
 
     You can also set this value by setting the MITTWALD_SSH_USER environment variable.
-
-  --sub-directory=<value>  specify a sub-directory within the app installation to upload
-
-    This is particularly useful when you only want to upload a specific sub-directory of the app installation, for
-    example when you are using a deployment tool that manages the app installation directory itself, and you only want
-    to upload exempt files, like environment specific configuration files or user data.
 ```
 
 ## `mw app versions [APP]`

--- a/docs/app.md
+++ b/docs/app.md
@@ -345,18 +345,19 @@ Download the filesystem of an app within a project to your local machine
 ```
 USAGE
   $ mw app download [INSTALLATION-ID] --target <value> [-q] [--ssh-user <value>] [--ssh-identity-file <value>]
-    [--exclude <value>...] [--dry-run] [--delete]
+    [--exclude <value>...] [--dry-run] [--delete] [--sub-directory <value>]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context.
 
 FLAGS
-  -q, --quiet               suppress process output and only display a machine-readable summary.
-      --delete              delete local files that are not present on the server
-      --dry-run             do not actually download the app installation
-      --exclude=<value>...  [default: ] exclude files matching the given pattern
-      --target=<value>      (required) target directory to download the app installation to
+  -q, --quiet                  suppress process output and only display a machine-readable summary.
+      --delete                 delete local files that are not present on the server
+      --dry-run                do not actually download the app installation
+      --exclude=<value>...     [default: ] exclude files matching the given pattern
+      --sub-directory=<value>  specify a sub-directory within the app installation to download
+      --target=<value>         (required) target directory to download the app installation to
 
 SSH CONNECTION FLAGS
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
@@ -400,6 +401,12 @@ FLAG DESCRIPTIONS
     will be used for this.
 
     You can also set this value by setting the MITTWALD_SSH_USER environment variable.
+
+  --sub-directory=<value>  specify a sub-directory within the app installation to download
+
+    This is particularly useful when you only want to download a specific sub-directory of the app installation, for
+    example when you are using a deployment tool that manages the app installation directory itself, and you only want
+    to download exempt files, like environment specific configuration files or user data.
 ```
 
 ## `mw app get [INSTALLATION-ID]`
@@ -1989,18 +1996,19 @@ Upload the filesystem of an app to a project
 ```
 USAGE
   $ mw app upload [INSTALLATION-ID] --source <value> [-q] [--ssh-user <value>] [--ssh-identity-file <value>]
-    [--exclude <value>...] [--dry-run] [--delete]
+    [--exclude <value>...] [--dry-run] [--delete] [--sub-directory <value>]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context.
 
 FLAGS
-  -q, --quiet               suppress process output and only display a machine-readable summary.
-      --delete              delete remote files that are not present locally
-      --dry-run             do not actually upload the app installation
-      --exclude=<value>...  [default: ] exclude files matching the given pattern
-      --source=<value>      (required) source directory from which to upload the app installation
+  -q, --quiet                  suppress process output and only display a machine-readable summary.
+      --delete                 delete remote files that are not present locally
+      --dry-run                do not actually upload the app installation
+      --exclude=<value>...     [default: ] exclude files matching the given pattern
+      --source=<value>         (required) source directory from which to upload the app installation
+      --sub-directory=<value>  specify a sub-directory within the app installation to upload
 
 SSH CONNECTION FLAGS
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
@@ -2047,6 +2055,12 @@ FLAG DESCRIPTIONS
     will be used for this.
 
     You can also set this value by setting the MITTWALD_SSH_USER environment variable.
+
+  --sub-directory=<value>  specify a sub-directory within the app installation to upload
+
+    This is particularly useful when you only want to upload a specific sub-directory of the app installation, for
+    example when you are using a deployment tool that manages the app installation directory itself, and you only want
+    to upload exempt files, like environment specific configuration files or user data.
 ```
 
 ## `mw app versions [APP]`

--- a/src/commands/app/download.tsx
+++ b/src/commands/app/download.tsx
@@ -14,6 +14,7 @@ import { sshUsageDocumentation } from "../../lib/resources/ssh/doc.js";
 import {
   appInstallationSyncFlags,
   appInstallationSyncFlagsToRsyncFlags,
+  buildRsyncConnectionString,
   filterFileDocumentation,
   filterFileToRsyncFlagsIfPresent,
 } from "../../lib/resources/app/sync.js";
@@ -48,7 +49,7 @@ export class Download extends ExecRenderBaseCommand<typeof Download, void> {
 
     const p = makeProcessRenderer(this.flags, "Downloading app installation");
 
-    const { host, user, directory } = await p.runStep(
+    const connectionData = await p.runStep(
       "getting connection data",
       async () => {
         return getSSHConnectionForAppInstallation(
@@ -65,6 +66,7 @@ export class Download extends ExecRenderBaseCommand<typeof Download, void> {
       }
     });
 
+    const rsyncHost = buildRsyncConnectionString(connectionData, this.flags);
     const rsyncOpts = [
       ...appInstallationSyncFlagsToRsyncFlags(this.flags),
       ...(await filterFileToRsyncFlagsIfPresent(target)),
@@ -74,7 +76,7 @@ export class Download extends ExecRenderBaseCommand<typeof Download, void> {
       p,
       "downloading app installation" + (dryRun ? " (dry-run)" : ""),
       "rsync",
-      [...rsyncOpts, `${user}@${host}:${directory}/`, target],
+      [...rsyncOpts, rsyncHost, target],
     );
 
     if (dryRun) {

--- a/src/commands/app/download.tsx
+++ b/src/commands/app/download.tsx
@@ -42,6 +42,17 @@ export class Download extends ExecRenderBaseCommand<typeof Download, void> {
       exists: false,
     }),
   };
+  static examples = [
+    {
+      description: "Download entire app to current working directory",
+      command: "$ <%= config.bin %> <%= command.id %> .",
+    },
+    {
+      description: "Download only shared dir from a deployer-managed app",
+      command:
+        "<%= config.bin %> <%= command.id %> --remote-sub-directory=shared .",
+    },
+  ];
 
   protected async exec(): Promise<void> {
     const appInstallationId = await this.withAppInstallationId(Download);

--- a/src/lib/resources/app/sync.ts
+++ b/src/lib/resources/app/sync.ts
@@ -35,7 +35,8 @@ export const appInstallationSyncFlags = (direction: "upload" | "download") => ({
     description:
       `This is particularly useful when you only want to ${direction} a specific sub-directory of the app installation, ` +
       "for example when you are using a deployment tool that manages the app installation directory itself, " +
-      `and you only want to ${direction} exempt files, like environment specific configuration files or user data.`,
+      `and you only want to ${direction} exempt files, like environment specific configuration files or user data. ` +
+      `For example, if you want to ${direction} ${direction === "upload" ? "to" : "from"} "/html/my-app-XXXXX/config", set "--remote-sub-directory=config".`,
   }),
 });
 

--- a/src/lib/resources/app/sync.ts
+++ b/src/lib/resources/app/sync.ts
@@ -30,7 +30,7 @@ export const appInstallationSyncFlags = (direction: "upload" | "download") => ({
         : "delete remote files that are not present locally",
     default: false,
   }),
-  "sub-directory": Flags.string({
+  "remote-sub-directory": Flags.string({
     summary: `specify a sub-directory within the app installation to ${direction}`,
     description:
       `This is particularly useful when you only want to ${direction} a specific sub-directory of the app installation, ` +

--- a/src/lib/resources/app/sync.ts
+++ b/src/lib/resources/app/sync.ts
@@ -58,12 +58,22 @@ export async function filterFileToRsyncFlagsIfPresent(
   return [];
 }
 
+/**
+ * Build the rsync connection string for the given SSH connection data and flag
+ * inputs.
+ *
+ * @param host Remote SSH hostname
+ * @param directory Remove base directory of the app installation
+ * @param user Remote SSH user
+ * @param subDirectory Optional sub-directory within the app installation to
+ *   sync
+ */
 export function buildRsyncConnectionString(
   { host, directory, user }: SSHConnectionData,
-  flags: AppInstallationSyncFlags,
+  { "sub-directory": subDirectory }: AppInstallationSyncFlags,
 ): string {
-  if (flags["sub-directory"]) {
-    directory = path.join(directory, flags["sub-directory"]).replace(/\/$/, "");
+  if (subDirectory) {
+    directory = path.join(directory, subDirectory).replace(/\/$/, "");
   }
 
   return `${user}@${host}:${directory}/`;

--- a/src/lib/resources/app/sync.ts
+++ b/src/lib/resources/app/sync.ts
@@ -63,7 +63,7 @@ export function buildRsyncConnectionString(
   flags: AppInstallationSyncFlags,
 ): string {
   if (flags["sub-directory"]) {
-    directory = path.join(directory, flags["sub-directory"]);
+    directory = path.join(directory, flags["sub-directory"]).replace(/\/$/, "");
   }
 
   return `${user}@${host}:${directory}/`;


### PR DESCRIPTION
This PR adds a flag to the `app download` and `app upload` command to restrict rsync to a specific sub directory on the remote side.

This is useful when you only want to up/download a specific subdirectory of the app installation, for example when you are using a deployment tool that manages the app installation directory itself, and you only want to up/download exempt files, like environment specific configuration files or user data.
