### PR TITLE
Target/source of app upload|download command should be arg, not flag

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -11,7 +11,7 @@ Manage apps, and app installations in your projects
 * [`mw app dependency list`](#mw-app-dependency-list)
 * [`mw app dependency update [INSTALLATION-ID]`](#mw-app-dependency-update-installation-id)
 * [`mw app dependency versions SYSTEMSOFTWARE`](#mw-app-dependency-versions-systemsoftware)
-* [`mw app download [INSTALLATION-ID]`](#mw-app-download-installation-id)
+* [`mw app download [INSTALLATION-ID] TARGET`](#mw-app-download-installation-id-target)
 * [`mw app get [INSTALLATION-ID]`](#mw-app-get-installation-id)
 * [`mw app install contao`](#mw-app-install-contao)
 * [`mw app install drupal`](#mw-app-install-drupal)
@@ -34,7 +34,7 @@ Manage apps, and app installations in your projects
 * [`mw app uninstall [INSTALLATION-ID]`](#mw-app-uninstall-installation-id)
 * [`mw app update [INSTALLATION-ID]`](#mw-app-update-installation-id)
 * [`mw app upgrade [INSTALLATION-ID]`](#mw-app-upgrade-installation-id)
-* [`mw app upload [INSTALLATION-ID]`](#mw-app-upload-installation-id)
+* [`mw app upload [INSTALLATION-ID] SOURCE`](#mw-app-upload-installation-id-source)
 * [`mw app versions [APP]`](#mw-app-versions-app)
 
 ## `mw app copy [INSTALLATION-ID]`
@@ -345,25 +345,25 @@ DESCRIPTION
   Get all available versions of a particular dependency
 ```
 
-## `mw app download [INSTALLATION-ID]`
+## `mw app download [INSTALLATION-ID] TARGET`
 
 Download the filesystem of an app within a project to your local machine
 
 ```
 USAGE
-  $ mw app download [INSTALLATION-ID] --target <value> [-q] [--ssh-user <value>] [--ssh-identity-file <value>]
-    [--exclude <value>...] [--dry-run] [--delete]
+  $ mw app download [INSTALLATION-ID] TARGET [-q] [--ssh-user <value>] [--ssh-identity-file <value>] [--exclude
+    <value>...] [--dry-run] [--delete]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context.
+  TARGET           target directory to download the app installation to
 
 FLAGS
   -q, --quiet               suppress process output and only display a machine-readable summary.
       --delete              delete local files that are not present on the server
       --dry-run             do not actually download the app installation
       --exclude=<value>...  [default: ] exclude files matching the given pattern
-      --target=<value>      (required) target directory to download the app installation to
 
 SSH CONNECTION FLAGS
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.
@@ -2004,25 +2004,25 @@ FLAG DESCRIPTIONS
     scripts), you can use this flag to easily get the IDs of created resources for further processing.
 ```
 
-## `mw app upload [INSTALLATION-ID]`
+## `mw app upload [INSTALLATION-ID] SOURCE`
 
 Upload the filesystem of an app to a project
 
 ```
 USAGE
-  $ mw app upload [INSTALLATION-ID] --source <value> [-q] [--ssh-user <value>] [--ssh-identity-file <value>]
-    [--exclude <value>...] [--dry-run] [--delete]
+  $ mw app upload [INSTALLATION-ID] SOURCE [-q] [--ssh-user <value>] [--ssh-identity-file <value>] [--exclude
+    <value>...] [--dry-run] [--delete]
 
 ARGUMENTS
   INSTALLATION-ID  ID or short ID of an app installation; this argument is optional if a default app installation is set
                    in the context.
+  SOURCE           source directory from which to upload the app installation
 
 FLAGS
   -q, --quiet               suppress process output and only display a machine-readable summary.
       --delete              delete remote files that are not present locally
       --dry-run             do not actually upload the app installation
       --exclude=<value>...  [default: ] exclude files matching the given pattern
-      --source=<value>      (required) source directory from which to upload the app installation
 
 SSH CONNECTION FLAGS
   --ssh-identity-file=<value>  the SSH identity file (private key) to use for public key authentication.

--- a/src/commands/app/download.tsx
+++ b/src/commands/app/download.tsx
@@ -4,7 +4,7 @@ import {
   makeProcessRenderer,
   processFlags,
 } from "../../rendering/process/process_flags.js";
-import { Flags } from "@oclif/core";
+import { Args } from "@oclif/core";
 import { Success } from "../../rendering/react/components/Success.js";
 import { ReactNode } from "react";
 import { getSSHConnectionForAppInstallation } from "../../lib/resources/ssh/appinstall.js";
@@ -30,21 +30,22 @@ export class Download extends ExecRenderBaseCommand<typeof Download, void> {
     filterFileDocumentation;
   static args = {
     ...appInstallationArgs,
-  };
-  static flags = {
-    ...processFlags,
-    ...sshConnectionFlags,
-    ...appInstallationSyncFlags("download"),
-    target: Flags.directory({
+    target: Args.directory({
       description: "target directory to download the app installation to",
       required: true,
       exists: false,
     }),
   };
+  static flags = {
+    ...processFlags,
+    ...sshConnectionFlags,
+    ...appInstallationSyncFlags("download"),
+  };
 
   protected async exec(): Promise<void> {
     const appInstallationId = await this.withAppInstallationId(Download);
-    const { "dry-run": dryRun, target, "ssh-user": sshUser } = this.flags;
+    const { "dry-run": dryRun, "ssh-user": sshUser } = this.flags;
+    const { target } = this.args;
 
     const p = makeProcessRenderer(this.flags, "Downloading app installation");
 

--- a/src/commands/app/upload.tsx
+++ b/src/commands/app/upload.tsx
@@ -4,7 +4,7 @@ import {
   makeProcessRenderer,
   processFlags,
 } from "../../rendering/process/process_flags.js";
-import { Flags } from "@oclif/core";
+import { Args } from "@oclif/core";
 import { Success } from "../../rendering/react/components/Success.js";
 import { ReactNode } from "react";
 import { getSSHConnectionForAppInstallation } from "../../lib/resources/ssh/appinstall.js";
@@ -31,21 +31,22 @@ export class Upload extends ExecRenderBaseCommand<typeof Upload, void> {
     filterFileDocumentation;
   static args = {
     ...appInstallationArgs,
-  };
-  static flags = {
-    ...processFlags,
-    ...sshConnectionFlags,
-    ...appInstallationSyncFlags("upload"),
-    source: Flags.directory({
+    source: Args.directory({
       description: "source directory from which to upload the app installation",
       required: true,
       exists: true,
     }),
   };
+  static flags = {
+    ...processFlags,
+    ...sshConnectionFlags,
+    ...appInstallationSyncFlags("upload"),
+  };
 
   protected async exec(): Promise<void> {
     const appInstallationId = await this.withAppInstallationId(Upload);
-    const { "dry-run": dryRun, source, "ssh-user": sshUser } = this.flags;
+    const { "dry-run": dryRun, "ssh-user": sshUser } = this.flags;
+    const { source } = this.args;
 
     const p = makeProcessRenderer(this.flags, "Uploading app installation");
 


### PR DESCRIPTION
This PR streamlines the flags+args of the `mw app upload|download` command.

Since these are required, it makes more sense to model them as positional arguments instead of flags.

Note that this change is very breaking, which is why we're introducing it before an eventual 1.0 release.

Fixes #394
