### PR TITLE
Add list of virtual hosts to "app get" command

### DIFF
--- a/src/lib/resources/app/buildAppURLsFromIngressList.ts
+++ b/src/lib/resources/app/buildAppURLsFromIngressList.ts
@@ -1,0 +1,29 @@
+import { MittwaldAPIV2 } from "@mittwald/api-client";
+
+type Ingress = MittwaldAPIV2.Components.Schemas.IngressIngress;
+
+/**
+ * Build a list of URLs for an app installation from a list of ingresses.
+ *
+ * @param ingresses A list of ingresses to search for the app installation ID;
+ *   typically all ingresses for a project
+ * @param appInstallationId The ID of the app installation to search for
+ * @returns A list of URLs that point to the app installation
+ */
+export default function buildAppURLsFromIngressList(
+  ingresses: Ingress[],
+  appInstallationId: string,
+): string[] {
+  const matchingURLs = [];
+  for (const virtualHost of ingresses) {
+    for (const path of virtualHost.paths) {
+      if (
+        "installationId" in path.target &&
+        path.target.installationId === appInstallationId
+      ) {
+        matchingURLs.push("https://" + virtualHost.hostname + path.path);
+      }
+    }
+  }
+  return matchingURLs;
+}

--- a/src/lib/resources/domain/virtualhost/hooks.ts
+++ b/src/lib/resources/domain/virtualhost/hooks.ts
@@ -1,0 +1,17 @@
+import { assertStatus } from "@mittwald/api-client";
+import { useRenderContext } from "../../../../rendering/react/context.js";
+import { usePromise } from "@mittwald/react-use-promise";
+
+export function useVirtualHosts(projectId: string) {
+  const { apiClient } = useRenderContext();
+  const virtualHosts = usePromise(
+    (projectId) =>
+      apiClient.domain.ingressListIngresses({
+        queryParameters: { projectId },
+      }),
+    [projectId],
+  );
+  assertStatus(virtualHosts, 200);
+
+  return virtualHosts.data;
+}

--- a/src/rendering/react/components/AppInstallation/AppInstallationDetails.tsx
+++ b/src/rendering/react/components/AppInstallation/AppInstallationDetails.tsx
@@ -12,6 +12,8 @@ import path from "path";
 import { isCustomAppInstallation } from "../../../../lib/resources/app/custom_installation.js";
 import maybe from "../../../../lib/util/maybe.js";
 import OptionalValue from "../OptionalValue.js";
+import { AppVirtualHosts } from "./AppVirtualHosts.js";
+
 type AppAppInstallation = MittwaldAPIV2.Components.Schemas.AppAppInstallation;
 type AppApp = MittwaldAPIV2.Components.Schemas.AppApp;
 
@@ -109,6 +111,7 @@ export const AppInstallationDetails: FC<{
       key="systemsoftware"
       appInstallation={appInstallation}
     />,
+    <AppVirtualHosts key="virtualhosts" appInstallation={appInstallation} />,
   ];
 
   return (

--- a/src/rendering/react/components/AppInstallation/AppVirtualHosts.tsx
+++ b/src/rendering/react/components/AppInstallation/AppVirtualHosts.tsx
@@ -1,0 +1,55 @@
+import React, { FC, PropsWithChildren } from "react";
+import maybe from "../../../../lib/util/maybe.js";
+import { useVirtualHosts } from "../../../../lib/resources/domain/virtualhost/hooks.js";
+import { Header } from "../Header.js";
+import { MittwaldAPIV2 } from "@mittwald/api-client";
+import { Box, Text } from "ink";
+import buildAppURLsFromIngressList from "../../../../lib/resources/app/buildAppURLsFromIngressList.js";
+
+type AppAppInstallation = MittwaldAPIV2.Components.Schemas.AppAppInstallation;
+
+const AppVirtualHostBox: FC<PropsWithChildren<{}>> = ({ children }) => {
+  return (
+    <Box flexDirection="column">
+      <Box marginY={1}>
+        <Header title="Linked virtual hosts" />
+      </Box>
+      {children}
+    </Box>
+  );
+};
+
+/**
+ * Component to display the virtual hosts linked to an app installation. There
+ * is no specific API endpoint to fetch this information, so we have to fetch
+ * all virtual hosts and filter them by the installation ID.
+ *
+ * @class
+ * @param appInstallation
+ */
+export const AppVirtualHosts: FC<{
+  appInstallation: AppAppInstallation;
+}> = ({ appInstallation }) => {
+  const virtualHosts = maybe(useVirtualHosts)(appInstallation.projectId);
+
+  if (!virtualHosts || virtualHosts.length === 0) {
+    return (
+      <AppVirtualHostBox>
+        <Text>No virtual hosts are linked to this app installation</Text>
+      </AppVirtualHostBox>
+    );
+  }
+
+  const matchingURLs = buildAppURLsFromIngressList(
+    virtualHosts,
+    appInstallation.id,
+  );
+
+  return (
+    <AppVirtualHostBox>
+      {matchingURLs.map((url, idx) => (
+        <Text key={idx}>{url}</Text>
+      ))}
+    </AppVirtualHostBox>
+  );
+};

--- a/src/rendering/react/components/AppInstallation/AppVirtualHosts.tsx
+++ b/src/rendering/react/components/AppInstallation/AppVirtualHosts.tsx
@@ -8,7 +8,7 @@ import buildAppURLsFromIngressList from "../../../../lib/resources/app/buildAppU
 
 type AppAppInstallation = MittwaldAPIV2.Components.Schemas.AppAppInstallation;
 
-const AppVirtualHostBox: FC<PropsWithChildren<{}>> = ({ children }) => {
+const AppVirtualHostBox: FC<PropsWithChildren> = ({ children }) => {
   return (
     <Box flexDirection="column">
       <Box marginY={1}>


### PR DESCRIPTION
This PR adds a new section to the output of the "app get" command, listing all virtual hosts that point to a given app installation.
