### PR TITLE
Print vhost hostname as URL, for better terminal usability

### DIFF
--- a/src/commands/domain/virtualhost/list.ts
+++ b/src/commands/domain/virtualhost/list.ts
@@ -44,7 +44,9 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
     const columns: ListColumns<ResponseItem> = {
       id: baseColumns.id,
       projectId: { header: "Project ID" },
-      hostname: {},
+      hostname: {
+        get: (r) => `https://${r.hostname}`,
+      },
       paths: {
         get: (r) =>
           r.paths


### PR DESCRIPTION
This PR changes the vhost list to print the hostname formatted as URL.

This allows for a better usability in the terminal, allowing you to CTRL+Click (in most terminal) directly on the hostname.
