### PR TITLE
Do not throw error on "context set" when context contains invalid data

### DIFF
--- a/src/commands/context/set.ts
+++ b/src/commands/context/set.ts
@@ -24,7 +24,9 @@ export class Set extends BaseCommand {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(Set);
-    const ctx = new Context(this.apiClient, this.config);
+    const ctx = new Context(this.apiClient, this.config, {
+      onInitError() {},
+    });
 
     if (flags["project-id"]) {
       const projectId = await ctx.setProjectId(flags["project-id"]);

--- a/src/lib/error/InvalidContextError.ts
+++ b/src/lib/error/InvalidContextError.ts
@@ -1,0 +1,1 @@
+export default class InvalidContextError extends Error {}


### PR DESCRIPTION
Fixes #928
