### PR TITLE
Temporary MySQL password should conform to MySQL password policy

### DIFF
--- a/src/lib/resources/database/mysql/temp_user.test.ts
+++ b/src/lib/resources/database/mysql/temp_user.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "@jest/globals";
+import { generateRandomPassword } from "./temp_user.js";
+
+describe("generateRandomPassword", () => {
+  it("should generate a password of the specified length", () => {
+    const length = 12;
+    const password = generateRandomPassword(length);
+    expect(password.length).toBe(length);
+  });
+
+  it("should include at least one lowercase character", () => {
+    const password = generateRandomPassword(12);
+    expect(/[a-z]/.test(password)).toBe(true);
+  });
+
+  it("should include at least one uppercase character", () => {
+    const password = generateRandomPassword(12);
+    expect(/[A-Z]/.test(password)).toBe(true);
+  });
+
+  it("should include at least one digit", () => {
+    const password = generateRandomPassword(12);
+    expect(/[0-9]/.test(password)).toBe(true);
+  });
+
+  it("should include at least one special character", () => {
+    const specialChars = "#!~%^*_+-=?{}()<>|.,;";
+    const password = generateRandomPassword(12);
+    expect(
+      new RegExp(
+        `[${specialChars.replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&")}]`,
+      ).test(password),
+    ).toBe(true);
+  });
+
+  it("should generate passwords that are unique", () => {
+    const password1 = generateRandomPassword(12);
+    const password2 = generateRandomPassword(12);
+    expect(password1).not.toBe(password2);
+  });
+
+  it("should work for passwords with length greater than 8", () => {
+    const password = generateRandomPassword(20);
+    expect(password.length).toBe(20);
+    expect(/[a-z]/.test(password)).toBe(true);
+    expect(/[A-Z]/.test(password)).toBe(true);
+    expect(/[0-9]/.test(password)).toBe(true);
+    const specialChars = "#!~%^*_+-=?{}()<>|.,;";
+    expect(
+      new RegExp(
+        `[${specialChars.replace(/[-[\]/{}()*+?.\\^$|]/g, "\\$&")}]`,
+      ).test(password),
+    ).toBe(true);
+  });
+});

--- a/src/lib/resources/database/mysql/temp_user.ts
+++ b/src/lib/resources/database/mysql/temp_user.ts
@@ -2,6 +2,7 @@ import type { MittwaldAPIV2 } from "@mittwald/api-client";
 import { assertStatus, MittwaldAPIV2Client } from "@mittwald/api-client";
 import assertSuccess from "../../../apiutil/assert_success.js";
 import { ProcessRenderer } from "../../../../rendering/process/process.js";
+import { randomInt } from "crypto";
 
 type DatabaseMySqlUser = MittwaldAPIV2.Components.Schemas.DatabaseMySqlUser;
 
@@ -56,20 +57,20 @@ export function generateRandomPassword(length: number = 32): string {
 
   // Ensure the password includes at least one of each required character type
   const passwordArray = [
-    lowercase[Math.floor(Math.random() * lowercase.length)],
-    uppercase[Math.floor(Math.random() * uppercase.length)],
-    digits[Math.floor(Math.random() * digits.length)],
-    specialChars[Math.floor(Math.random() * specialChars.length)],
+    lowercase[randomInt(0, lowercase.length)],
+    uppercase[randomInt(0, uppercase.length)],
+    digits[randomInt(0, digits.length)],
+    specialChars[randomInt(0, specialChars.length)],
   ];
 
   // Fill the remaining characters randomly
   for (let i = passwordArray.length; i < length; i++) {
-    passwordArray.push(allChars[Math.floor(Math.random() * allChars.length)]);
+    passwordArray.push(allChars[randomInt(0, allChars.length)]);
   }
 
   // Shuffle the array to avoid predictable patterns
   for (let i = passwordArray.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = randomInt(0, i + 1);
     [passwordArray[i], passwordArray[j]] = [passwordArray[j], passwordArray[i]];
   }
 

--- a/src/lib/resources/database/mysql/temp_user.ts
+++ b/src/lib/resources/database/mysql/temp_user.ts
@@ -1,6 +1,5 @@
 import type { MittwaldAPIV2 } from "@mittwald/api-client";
 import { assertStatus, MittwaldAPIV2Client } from "@mittwald/api-client";
-import { randomBytes } from "crypto";
 import assertSuccess from "../../../apiutil/assert_success.js";
 import { ProcessRenderer } from "../../../../rendering/process/process.js";
 
@@ -38,8 +37,43 @@ async function retrieveTemporaryUser(
   return userResponse.data;
 }
 
-function generateRandomPassword(): string {
-  return randomBytes(32).toString("base64");
+/**
+ * Generates a random password that fulfills the requirements for [mysql
+ * passwords][mysql].
+ *
+ * [mysql]: https://developer.mittwald.de/docs/v2/api/security/passwords#mysql
+ *
+ * @param length Desired length in characters
+ * @returns A randomly generated password
+ */
+export function generateRandomPassword(length: number = 32): string {
+  // Character pools
+  const lowercase = "abcdefghijklmnopqrstuvwxyz";
+  const uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const digits = "0123456789";
+  const specialChars = "#!~%^*_+-=?{}()<>|.,;";
+  const allChars = lowercase + uppercase + digits + specialChars;
+
+  // Ensure the password includes at least one of each required character type
+  const passwordArray = [
+    lowercase[Math.floor(Math.random() * lowercase.length)],
+    uppercase[Math.floor(Math.random() * uppercase.length)],
+    digits[Math.floor(Math.random() * digits.length)],
+    specialChars[Math.floor(Math.random() * specialChars.length)],
+  ];
+
+  // Fill the remaining characters randomly
+  for (let i = passwordArray.length; i < length; i++) {
+    passwordArray.push(allChars[Math.floor(Math.random() * allChars.length)]);
+  }
+
+  // Shuffle the array to avoid predictable patterns
+  for (let i = passwordArray.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [passwordArray[i], passwordArray[j]] = [passwordArray[j], passwordArray[i]];
+  }
+
+  return passwordArray.join("");
 }
 
 /**


### PR DESCRIPTION
This PR ensures that randomly generated password for temporary MySQL users conform to the respective password policy.[^1]

Fixes #1026

[^1]: https://developer.mittwald.de/docs/v2/api/security/passwords#mysql
