### PR TITLE
Add commands to manage container registries

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,9 @@
           }
         }
       },
+      "registry": {
+        "description": "Manage container registries"
+      },
       "article": {
         "description": "Query available hosting articles"
       },

--- a/src/commands/registry/create.tsx
+++ b/src/commands/registry/create.tsx
@@ -24,20 +24,20 @@ export class Create extends ExecRenderBaseCommand<typeof Create, Result> {
     ...projectFlags,
     ...processFlags,
     uri: Flags.string({
-      description: "URI of the registry",
+      summary: "uri of the registry",
       required: true,
     }),
     description: Flags.string({
-      description: "Description of the registry",
+      summary: "description of the registry",
       required: true,
     }),
     username: Flags.string({
-      description: "Username for registry authentication",
+      summary: "username for registry authentication",
       required: false,
       dependsOn: ["password"],
     }),
     password: Flags.string({
-      description: "Password for registry authentication",
+      summary: "password for registry authentication",
       required: false,
       dependsOn: ["username"],
     }),

--- a/src/commands/registry/create.tsx
+++ b/src/commands/registry/create.tsx
@@ -1,0 +1,104 @@
+import { ExecRenderBaseCommand } from "../../lib/basecommands/ExecRenderBaseCommand.js";
+import {
+  makeProcessRenderer,
+  processFlags,
+} from "../../rendering/process/process_flags.js";
+import { ReactNode } from "react";
+import { assertStatus } from "@mittwald/api-client-commons";
+import { Success } from "../../rendering/react/components/Success.js";
+import { Value } from "../../rendering/react/components/Value.js";
+import { projectFlags } from "../../lib/resources/project/flags.js";
+import { Flags } from "@oclif/core";
+import type { MittwaldAPIV2 } from "@mittwald/api-client";
+
+type ContainerCreateRegistry =
+  MittwaldAPIV2.Components.Schemas.ContainerCreateRegistry;
+
+type Result = {
+  registryId: string;
+};
+
+export class Create extends ExecRenderBaseCommand<typeof Create, Result> {
+  static summary = "Create a new container registry";
+  static flags = {
+    ...projectFlags,
+    ...processFlags,
+    uri: Flags.string({
+      description: "URI of the registry",
+      required: true,
+    }),
+    description: Flags.string({
+      description: "Description of the registry",
+      required: true,
+    }),
+    username: Flags.string({
+      description: "Username for registry authentication",
+      required: false,
+      dependsOn: ["password"],
+    }),
+    password: Flags.string({
+      description: "Password for registry authentication",
+      required: false,
+      dependsOn: ["username"],
+    }),
+  };
+
+  protected async exec(): Promise<Result> {
+    const process = makeProcessRenderer(
+      this.flags,
+      "Creating a new container registry",
+    );
+    const projectId = await this.withProjectId(Create);
+    const { uri, description, username, password } = this.flags;
+
+    const registryCreationPayload: ContainerCreateRegistry = {
+      uri,
+      description,
+    };
+
+    if (username && password) {
+      registryCreationPayload.credentials = {
+        username,
+        password,
+      };
+    }
+
+    const { id: registryId } = await process.runStep(
+      "creating container registry",
+      async () => {
+        const r = await this.apiClient.container.createRegistry({
+          projectId,
+          data: registryCreationPayload,
+        });
+        assertStatus(r, 201);
+        return r.data;
+      },
+    );
+
+    const registry = await process.runStep(
+      "checking newly created container registry",
+      async () => {
+        const r = await this.apiClient.container.getRegistry({
+          registryId,
+        });
+        assertStatus(r, 200);
+        return r.data;
+      },
+    );
+
+    await process.complete(
+      <Success>
+        The container registry "<Value>{registry.description}</Value>" at{" "}
+        <Value>{registry.uri}</Value> was successfully created.
+      </Success>,
+    );
+
+    return { registryId };
+  }
+
+  protected render({ registryId }: Result): ReactNode {
+    if (this.flags.quiet) {
+      return registryId;
+    }
+  }
+}

--- a/src/commands/registry/delete.ts
+++ b/src/commands/registry/delete.ts
@@ -1,0 +1,25 @@
+import { DeleteBaseCommand } from "../../lib/basecommands/DeleteBaseCommand.js";
+import assertSuccess from "../../lib/apiutil/assert_success.js";
+import { Args } from "@oclif/core";
+
+export default class Delete extends DeleteBaseCommand<typeof Delete> {
+  static description = "Delete a container registry";
+  static resourceName = "container registry";
+
+  static flags = { ...DeleteBaseCommand.baseFlags };
+  static args = {
+    "registry-id": Args.string({
+      description: "The ID of the container registry to delete",
+      required: true,
+    }),
+  };
+
+  protected async deleteResource(): Promise<void> {
+    const registryId = this.args["registry-id"];
+    const response = await this.apiClient.container.deleteRegistry({
+      registryId,
+    });
+
+    assertSuccess(response);
+  }
+}

--- a/src/commands/registry/delete.ts
+++ b/src/commands/registry/delete.ts
@@ -9,7 +9,7 @@ export default class Delete extends DeleteBaseCommand<typeof Delete> {
   static flags = { ...DeleteBaseCommand.baseFlags };
   static args = {
     "registry-id": Args.string({
-      description: "The ID of the container registry to delete",
+      summary: "id of the container registry to delete",
       required: true,
     }),
   };

--- a/src/commands/registry/list.ts
+++ b/src/commands/registry/list.ts
@@ -1,0 +1,48 @@
+import { Simplify } from "@mittwald/api-client-commons";
+import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
+import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
+import { projectFlags } from "../../lib/resources/project/flags.js";
+import { ListColumns } from "../../rendering/formatter/Table.js";
+
+type ContainerRegistry = MittwaldAPIV2.Components.Schemas.ContainerRegistry;
+
+type ResponseItem = Simplify<ContainerRegistry>;
+type Response = Awaited<
+  ReturnType<MittwaldAPIV2Client["container"]["listRegistries"]>
+>;
+
+export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
+  static description = "List container registries.";
+
+  static aliases = ["registry:ls"];
+  static args = {};
+  static flags = {
+    ...ListBaseCommand.baseFlags,
+    ...projectFlags,
+  };
+
+  public async getData(): Promise<Response> {
+    const projectId = await this.withProjectId(List);
+    return this.apiClient.container.listRegistries({ projectId });
+  }
+
+  protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {
+    const { id } = super.getColumns(data);
+    return {
+      id,
+      description: {},
+      uri: {
+        header: "URI",
+      },
+      credentials: {
+        header: "Credentials",
+        get: (registry) => {
+          if (!registry.credentials) {
+            return "";
+          }
+          return `${registry.credentials.username} (${registry.credentials.valid ? "valid" : "invalid"})`;
+        },
+      },
+    };
+  }
+}

--- a/src/commands/registry/update.tsx
+++ b/src/commands/registry/update.tsx
@@ -1,0 +1,96 @@
+import { ExecRenderBaseCommand } from "../../lib/basecommands/ExecRenderBaseCommand.js";
+import { Args, Flags } from "@oclif/core";
+import { ReactNode } from "react";
+import {
+  makeProcessRenderer,
+  processFlags,
+} from "../../rendering/process/process_flags.js";
+import { Success } from "../../rendering/react/components/Success.js";
+import assertSuccess from "../../lib/apiutil/assert_success.js";
+import type { MittwaldAPIV2 } from "@mittwald/api-client";
+
+type ContainerUpdateRegistry =
+  MittwaldAPIV2.Components.Schemas.ContainerUpdateRegistry;
+
+type UpdateResult = void;
+
+export default class Update extends ExecRenderBaseCommand<
+  typeof Update,
+  UpdateResult
+> {
+  static description = "Update an existing container registry";
+  static args = {
+    "registry-id": Args.string({
+      description: "The ID of the container registry to update",
+      required: true,
+    }),
+  };
+  static flags = {
+    ...processFlags,
+    description: Flags.string({
+      description: "New description for the registry",
+    }),
+    uri: Flags.string({
+      description: "New URI for the registry",
+    }),
+    username: Flags.string({
+      description: "Username for registry authentication",
+      dependsOn: ["password"],
+    }),
+    password: Flags.string({
+      description: "Password for registry authentication",
+      dependsOn: ["username"],
+    }),
+  };
+
+  protected async exec(): Promise<void> {
+    const registryId = this.args["registry-id"];
+    const process = makeProcessRenderer(
+      this.flags,
+      "Updating container registry",
+    );
+
+    const { description, uri, username, password } = this.flags;
+
+    const registryUpdatePayload: ContainerUpdateRegistry = {};
+
+    if (description) {
+      registryUpdatePayload.description = description;
+    }
+
+    if (uri) {
+      registryUpdatePayload.uri = uri;
+    }
+
+    if (username && password) {
+      registryUpdatePayload.credentials = {
+        username,
+        password,
+      };
+    }
+
+    if (Object.keys(registryUpdatePayload).length == 0) {
+      await process.complete(
+        <Success>Nothing to change. Have a good day!</Success>,
+      );
+      return;
+    }
+
+    await process.runStep("Updating container registry", async () => {
+      const response = await this.apiClient.container.updateRegistry({
+        registryId,
+        data: registryUpdatePayload,
+      });
+      assertSuccess(response);
+    });
+
+    await process.complete(
+      <Success>Your container registry has successfully been updated.</Success>,
+    );
+    return;
+  }
+
+  protected render(): ReactNode {
+    return true;
+  }
+}

--- a/src/commands/registry/update.tsx
+++ b/src/commands/registry/update.tsx
@@ -21,24 +21,24 @@ export default class Update extends ExecRenderBaseCommand<
   static description = "Update an existing container registry";
   static args = {
     "registry-id": Args.string({
-      description: "The ID of the container registry to update",
+      summary: "id of the container registry to update",
       required: true,
     }),
   };
   static flags = {
     ...processFlags,
     description: Flags.string({
-      description: "New description for the registry",
+      summary: "new description for the registry",
     }),
     uri: Flags.string({
-      description: "New URI for the registry",
+      summary: "new uri for the registry",
     }),
     username: Flags.string({
-      description: "Username for registry authentication",
+      summary: "username for registry authentication",
       dependsOn: ["password"],
     }),
     password: Flags.string({
-      description: "Password for registry authentication",
+      summary: "password for registry authentication",
       dependsOn: ["username"],
     }),
   };


### PR DESCRIPTION
This PR adds the following commands:

- `mw registry create`
- `mw registry list`
- `mw registry update`
- `mw registry delete`

Relates to #1150

- **feat: add container registry management commands**
- **refactor: replace `description` with `summary` in registry commands**
