### PR TITLE
feat: add `--path-to-container` flag for virtual host creation

### DIFF
--- a/docs/domain.md
+++ b/docs/domain.md
@@ -177,16 +177,17 @@ Create a new ingress
 
 ```
 USAGE
-  $ mw domain virtualhost create --hostname <value> [-q] [-p <value>] [--path-to-app <value>...] [--path-to-url
-  <value>...]
+  $ mw domain virtualhost create --hostname <value> [-q] [-p <value>] [--path-to-app <value>...] [--path-to-url <value>...]
+    [--path-to-container <value>...]
 
 FLAGS
-  -p, --project-id=<value>      ID or short ID of a project; this flag is optional if a default project is set in the
-                                context
-  -q, --quiet                   suppress process output and only display a machine-readable summary
-      --hostname=<value>        (required) the hostname of the ingress
-      --path-to-app=<value>...  add a path mapping to an app
-      --path-to-url=<value>...  add a path mapping to an external url
+  -p, --project-id=<value>            ID or short ID of a project; this flag is optional if a default project is set in
+                                      the context
+  -q, --quiet                         suppress process output and only display a machine-readable summary
+      --hostname=<value>              (required) the hostname of the ingress
+      --path-to-app=<value>...        add a path mapping to an app
+      --path-to-container=<value>...  add a path mapping to a container
+      --path-to-url=<value>...        add a path mapping to an external url
 
 DESCRIPTION
   Create a new ingress
@@ -220,6 +221,13 @@ FLAG DESCRIPTIONS
     This flag can be used to map a specific URL path to an app; the value for this flag should be the URL path and the
     app ID, separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745. You can specify this flag multiple times
     to map multiple paths to different apps, and also combine it with the other --path-to-* flags.
+
+  --path-to-container=<value>...  add a path mapping to a container
+
+    This flag can be used to map a specific URL path to a container; the value for this flag should be the URL path, the
+    container ID and the target port, each separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745:80/tcp. You
+    can specify this flag multiple times to map multiple paths to different containers, and also combine it with the
+    other --path-to-* flags.
 
   --path-to-url=<value>...  add a path mapping to an external url
 

--- a/src/commands/domain/virtualhost/create.tsx
+++ b/src/commands/domain/virtualhost/create.tsx
@@ -63,6 +63,12 @@ export default class Create extends ExecRenderBaseCommand<
       description:
         "This flag can be used to map a specific URL path to an external URL; the value for this flag should be the URL path and the external URL, separated by a colon, e.g. /:https://redirect.example. You can specify this flag multiple times to map multiple paths to different external URLs, and also combine it with the other --path-to-* flags.",
     }),
+    "path-to-container": Flags.string({
+      summary: "add a path mapping to a container",
+      multiple: true,
+      description:
+        "This flag can be used to map a specific URL path to a container; the value for this flag should be the URL path, the container ID and the target port, each separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745:80/tcp. You can specify this flag multiple times to map multiple paths to different containers, and also combine it with the other --path-to-* flags.",
+    }),
   };
 
   protected async exec(): Promise<CreateResult> {
@@ -79,6 +85,14 @@ export default class Create extends ExecRenderBaseCommand<
     for (const pathToUrl of this.flags["path-to-url"] ?? []) {
       const [path, url] = pathToUrl.split(":");
       paths.push({ path, target: { url } });
+    }
+
+    for (const pathToContainer of this.flags["path-to-container"] ?? []) {
+      const [path, container, portProtocol] = pathToContainer.split(":", 3);
+      paths.push({
+        path,
+        target: { container: { id: container, portProtocol } },
+      });
     }
 
     const { id: ingressId } = await process.runStep(


### PR DESCRIPTION
Introduced the `--path-to-container` flag, allowing users to map specific URL paths to container targets using container ID and port protocol. Enhances flexibility in creating virtual hosts with container-based routing.

Relates to #1150
