### PR TITLE
refactor: simplify stack enrichment and command output defaults

### DIFF
--- a/src/commands/stack/deploy.tsx
+++ b/src/commands/stack/deploy.tsx
@@ -50,26 +50,12 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, DeployResult> {
 
     const result: DeployResult = { restartedServices: [] };
 
-    const stack = await r.runStep("getting stack", async () => {
-      const resp = await this.apiClient.container.getStack({ stackId });
-      assertStatus(resp, 200);
-
-      return resp.data;
-    });
-
     const env = await collectEnvironment(process.env, envFile);
     let stackDefinition = await loadStackFromFile(composeFile, env);
 
     stackDefinition = sanitizeStackDefinition(stackDefinition);
-    stackDefinition = await r.runStep(
-      "getting image configurations",
-      async () => {
-        return enrichStackDefinition(
-          this.apiClient,
-          stack.projectId,
-          stackDefinition,
-        );
-      },
+    stackDefinition = await r.runStep("getting image configurations", () =>
+      enrichStackDefinition(stackDefinition),
     );
 
     this.debug("complete stack definition: %O", stackDefinition);

--- a/src/commands/stack/ps.ts
+++ b/src/commands/stack/ps.ts
@@ -48,7 +48,7 @@ export class ListContainers extends ListBaseCommand<
         get: (svc) => svc.deployedState.image,
       },
       command: {
-        get: (svc) => svc.deployedState.command?.join(" "),
+        get: (svc) => svc.deployedState.command?.join(" ") ?? "(from image)",
       },
       description: {},
       ports: {


### PR DESCRIPTION
It is no longer necessary to provide command+entrypoint client-side, because they can be automatically determined by the API.
