### PR TITLE
chore: update Node.js engine requirement to v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "clean": "(rimraf --glob dist tsconfig.*.tsbuildinfo) | true",
@@ -223,7 +223,7 @@
     ],
     "update": {
       "node": {
-        "version": "18.20.4"
+        "version": "20.19.3"
       },
       "s3": {
         "xz": true,


### PR DESCRIPTION
Node.js v18 is EOL since May 2025; raise the minimum requirement to v20. This will also unblock a few pending package upgrades.
