### PR TITLE
fix: replace cat /dev/zero with sleep infinity in SSH tunnels

### DIFF
--- a/src/commands/container/port-forward.tsx
+++ b/src/commands/container/port-forward.tsx
@@ -82,7 +82,7 @@ export class PortForward extends ExecRenderBaseCommand<
         .flat(),
     });
 
-    cp.spawnSync("ssh", [...sshArgs, "cat", "/dev/zero"], {
+    cp.spawnSync("ssh", [...sshArgs, "sleep", "infinity"], {
       stdio: ["ignore", process.stdout, process.stderr],
     });
     return {};

--- a/src/commands/database/mysql/port-forward.tsx
+++ b/src/commands/database/mysql/port-forward.tsx
@@ -64,7 +64,7 @@ export class PortForward extends ExecRenderBaseCommand<
       additionalFlags: ["-L", `${port}:${hostname}:3306`],
     });
 
-    cp.spawnSync("ssh", [...sshArgs, "cat", "/dev/zero"], {
+    cp.spawnSync("ssh", [...sshArgs, "sleep", "infinity"], {
       stdio: ["ignore", process.stdout, process.stderr],
     });
     return {};


### PR DESCRIPTION
## Summary
• Replace `cat /dev/zero` with `sleep infinity` in SSH tunnel commands
• Fixes excessive CPU usage caused by continuous null byte output
• Affects container and MySQL database port forwarding commands

🤖 Generated with [Claude Code](https://claude.ai/code)