### PR TITLE
fix: explicitly exit process after oclif.flush

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -5,5 +5,8 @@ import handleError from "../dist/lib/error/handleError.js";
 
 oclif
   .run(process.argv.slice(2), import.meta.url)
-  .then(oclif.flush)
+  .then(async () => {
+    await oclif.flush();
+    process.exit(0);
+  })
   .catch(handleError);


### PR DESCRIPTION
Possible fix for #1323?
