### PR TITLE
fix: support env_file arrays in docker-compose.yml

### DIFF
--- a/src/lib/resources/stack/enrich.test.ts
+++ b/src/lib/resources/stack/enrich.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+
+const mockReadFile = jest.fn<typeof import("fs/promises").readFile>();
+
+jest.unstable_mockModule("fs/promises", () => ({
+  readFile: mockReadFile,
+}));
+
+const { enrichStackDefinition } = await import("./enrich.js");
+
+describe("enrichStackDefinition", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should handle service without env_file", async () => {
+    const input = {
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          ports: ["80:80"],
+        },
+      },
+    };
+
+    const result = await enrichStackDefinition(input);
+
+    expect(result).toEqual(input);
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it("should handle single env_file as string", async () => {
+    mockReadFile.mockResolvedValueOnce("FOO=bar\nBAZ=qux");
+
+    const input = {
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          env_file: ".env",
+        },
+      },
+    };
+
+    const result = await enrichStackDefinition(input);
+
+    expect(mockReadFile).toHaveBeenCalledWith(".env", "utf-8");
+    expect(result).toEqual({
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          envs: {
+            FOO: "bar",
+            BAZ: "qux",
+          },
+        },
+      },
+    });
+  });
+
+  it("should handle env_file as array", async () => {
+    mockReadFile
+      .mockResolvedValueOnce("FOO=bar\nBAZ=qux")
+      .mockResolvedValueOnce("FOO=overridden\nNEW=value");
+
+    const input = {
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          env_file: [".env", ".env.local"],
+        },
+      },
+    };
+
+    const result = await enrichStackDefinition(input);
+
+    expect(mockReadFile).toHaveBeenCalledWith(".env", "utf-8");
+    expect(mockReadFile).toHaveBeenCalledWith(".env.local", "utf-8");
+    expect(result).toEqual({
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          envs: {
+            FOO: "overridden", // Later file should override
+            BAZ: "qux",
+            NEW: "value",
+          },
+        },
+      },
+    });
+  });
+
+  it("should merge env_file variables with existing envs", async () => {
+    mockReadFile.mockResolvedValueOnce("FOO=from_file\nFILE_VAR=file_value");
+
+    const input = {
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          env_file: ".env",
+          envs: {
+            FOO: "existing", // Should override env_file
+            EXISTING_VAR: "existing_value",
+          },
+        },
+      },
+    };
+
+    const result = await enrichStackDefinition(input);
+
+    expect(result).toEqual({
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          envs: {
+            FOO: "existing", // Existing envs take precedence
+            FILE_VAR: "file_value",
+            EXISTING_VAR: "existing_value",
+          },
+        },
+      },
+    });
+  });
+
+  it("should handle multiple services with different env_file configurations", async () => {
+    mockReadFile
+      .mockResolvedValueOnce("NGINX_VAR=nginx_value")
+      .mockResolvedValueOnce("APP_VAR=app_value1")
+      .mockResolvedValueOnce("APP_VAR=app_value2\nOTHER=other");
+
+    const input = {
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          env_file: ".env.nginx",
+        },
+        app: {
+          image: "app:latest",
+          env_file: [".env.app", ".env.app.local"],
+        },
+        db: {
+          image: "postgres:latest",
+          // No env_file
+        },
+      },
+    };
+
+    const result = await enrichStackDefinition(input);
+
+    expect(result).toEqual({
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          envs: {
+            NGINX_VAR: "nginx_value",
+          },
+        },
+        app: {
+          image: "app:latest",
+          envs: {
+            APP_VAR: "app_value2", // Later file overrides
+            OTHER: "other",
+          },
+        },
+        db: {
+          image: "postgres:latest",
+        },
+      },
+    });
+  });
+
+  it("should handle empty env files", async () => {
+    mockReadFile.mockResolvedValueOnce("");
+
+    const input = {
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          env_file: ".env",
+        },
+      },
+    };
+
+    const result = await enrichStackDefinition(input);
+
+    expect(result).toEqual({
+      services: {
+        nginx: {
+          image: "nginx:latest",
+          envs: {},
+        },
+      },
+    });
+  });
+});

--- a/src/lib/resources/stack/enrich.ts
+++ b/src/lib/resources/stack/enrich.ts
@@ -33,8 +33,17 @@ async function setEnvironmentFromEnvFile(
   }
 
   const enriched = structuredClone(service) as ContainerServiceInput;
-  const envFileContent = await readFile(service.env_file, "utf-8");
-  const envVars = parse(envFileContent);
+  const envFiles = Array.isArray(service.env_file)
+    ? service.env_file
+    : [service.env_file];
+
+  let envVars = {};
+
+  for (const envFile of envFiles) {
+    const envFileContent = await readFile(envFile, "utf-8");
+    const fileEnvVars = parse(envFileContent);
+    envVars = { ...envVars, ...fileEnvVars };
+  }
 
   delete enriched.env_file;
   enriched.envs = {

--- a/src/lib/resources/stack/types.ts
+++ b/src/lib/resources/stack/types.ts
@@ -6,7 +6,7 @@ type ContainerServiceDeclareRequest =
 export type ContainerServiceInput = ContainerServiceDeclareRequest & {
   command?: string[] | string;
   entrypoint?: string[] | string;
-  env_file?: string;
+  env_file?: string | string[];
   environment?: {
     [k: string]: string;
   };


### PR DESCRIPTION
## Summary
- Fix TypeError when env_file is specified as an array in Docker Compose files
- Support both single string and array formats for env_file as per Docker Compose specification

Fixes #1392

🤖 Generated with [Claude Code](https://claude.ai/code)