### PR TITLE
fix: add conditional check for 412 responses with "if-event-reached" header in API retry logic

### DIFF
--- a/src/lib/apiutil/api_retry.ts
+++ b/src/lib/apiutil/api_retry.ts
@@ -40,10 +40,12 @@ export function configureAxiosRetry(axios: AxiosInstance) {
       }
 
       const isSafeRequest = error.config?.method?.toLowerCase() === "get";
+      const isConditionalRequest =
+        !!error.config?.headers?.["if-event-reached"];
       const isPreconditionFailed = error.response?.status === 412;
       const isAccessDenied = error.response?.status === 403;
 
-      if (isPreconditionFailed) {
+      if (isPreconditionFailed && isConditionalRequest) {
         return true;
       }
 


### PR DESCRIPTION
Fixes #1399
