### PR TITLE
chore: discontinue build of macOS pkg files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,50 +90,11 @@ jobs:
           name: pkg-windows
           path: dist/win32/*.exe
 
-  build-macos:
-    runs-on: macos-13
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: yarn
-
-      - name: Set version in package json
-        run:
-          npm version ${GITHUB_REF#refs/tags/} --no-git-tag-version
-          --no-workspaces-update
-
-      - name: Build
-        run: yarn compile
-
-      - name: Build all possible packages
-        run: yarn package:macos
-
-      - name: Upload to S3
-        run: yarn oclif upload macos
-        env:
-          AWS_REGION: eu-central-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Save artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: pkg-macos
-          path: dist/macos/*.pkg
-
   release-npm:
     runs-on: ubuntu-latest
     needs:
       - build-linux
       - build-windows
-      - build-macos
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -178,7 +139,7 @@ jobs:
           gh release create ${GITHUB_REF#refs/tags/} --title
           ${GITHUB_REF#refs/tags/} --generate-notes --verify-tag
           --discussion-category Announcements pkg-tarballs/*.tar.gz
-          pkg-windows/*.exe pkg-macos/*.pkg
+          pkg-windows/*.exe
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -187,7 +148,6 @@ jobs:
     needs:
       - build-linux
       - build-windows
-      - build-macos
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
This PR discontinues the building of macOS pkg files.

The pkg build was a leftover from the past. Moreover, installation via PKG file was never recommended, neither in this project's README, nor in [the developer docs](https://developer.mittwald.de/docs/v2/cli/usage/install/). Furthermore, PKG installation was always cumbersome because we never bothered signing these packages.

For macOS users, the recommended way of installation has always been Homebrew, which will continue to work as usual.
