### PR TITLE
chore(deps): ensure that all eslint-related packages are upgraded together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
           - "jest"
           - "ts-test"
           - "@jest/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This PR asserts that all eslint-related packages are upgraded together.

This prevents issues like in #1648, where ESLint was bumped, but - as it turns out - some @typescript-eslint/* package didn't have a compatible version, yet. 
