### PR TITLE
fix: flush oclif output buffers on error

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -9,4 +9,6 @@ oclif
     await oclif.flush();
     process.exit(0);
   })
-  .catch(handleError);
+  .catch(async (error) => {
+    await handleError(error);
+  });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=20.7.0"
   },
   "scripts": {
-    "clean": "(rimraf --glob dist tsconfig.*.tsbuildinfo) | true",
+    "clean": "rimraf --glob 'dist' 'tsconfig*.tsbuildinfo' || true",
     "compile": "tsc --build tsconfig.json",
     "format": "yarn format:prettier --write",
     "format:prettier": "prettier $@ '**/*.{ts,tsx,yaml,yml,json,md,mdx}'",

--- a/src/lib/basecommands/ExecRenderBaseCommand.tsx
+++ b/src/lib/basecommands/ExecRenderBaseCommand.tsx
@@ -34,7 +34,7 @@ export abstract class ExecRenderBaseCommand<
     const result = await this.exec();
     const wrappedRender = wrapRender(this.render.bind(this));
 
-    render(
+    const handle = render(
       <RenderContextProvider
         value={{
           apiClient: this.apiClient,
@@ -46,6 +46,8 @@ export abstract class ExecRenderBaseCommand<
         </Suspense>
       </RenderContextProvider>,
     );
+
+    await handle.waitUntilExit();
   }
 
   protected abstract render(executionResult: TRes): ReactNode;

--- a/src/lib/basecommands/RenderBaseCommand.tsx
+++ b/src/lib/basecommands/RenderBaseCommand.tsx
@@ -54,9 +54,12 @@ export abstract class RenderBaseCommand<
 
   public async run(): Promise<void> {
     const onError = () => {
-      setImmediate(() => {
+      setImmediate(async () => {
         handle.unmount();
-        process.exit(1);
+        import("@oclif/core").then(async (oclif) => {
+          await oclif.default.flush();
+          process.exit(1);
+        });
       });
     };
 

--- a/src/lib/error/handleError.ts
+++ b/src/lib/error/handleError.ts
@@ -1,3 +1,4 @@
+import oclif from "@oclif/core";
 import { OclifError, PrettyPrintableError } from "@oclif/core/interfaces";
 import { ApiClientError, AxiosResponse } from "@mittwald/api-client-commons";
 import type { MittwaldAPIV2 } from "@mittwald/api-client";
@@ -8,22 +9,25 @@ type CommonsValidationErrors =
   MittwaldAPIV2.Components.Schemas.CommonsValidationErrors;
 
 // noinspection JSUnusedGlobalSymbols
-export default function handleError(
+export default async function handleError(
   error: Error &
     Partial<PrettyPrintableError> &
     Partial<OclifError> & {
       skipOclifErrorHandling?: boolean;
     },
-): void {
+): Promise<void> {
   if (!isUnexpectedError(error)) {
+    await oclif.flush();
     process.exit(1);
   }
 
   if (error instanceof ExitError) {
+    await oclif.flush();
     process.exit(error.oclif.exit);
   }
 
-  renderError(error);
+  await renderError(error);
+  await oclif.flush();
   process.exit(1);
 }
 

--- a/src/rendering/react/error.tsx
+++ b/src/rendering/react/error.tsx
@@ -7,6 +7,7 @@ import { ErrorBox } from "./components/ErrorBox.js";
  * @param err The error to render. May be anything; the ErrorBox component will
  *   handle it.
  */
-export function renderError(err: unknown) {
-  render(<ErrorBox err={err} />);
+export async function renderError(err: unknown): Promise<void> {
+  const handle = render(<ErrorBox err={err} />);
+  await handle.waitUntilExit();
 }


### PR DESCRIPTION
Trying to narrow down #1323 even further, i've discovered some passages that might also need flushing, as well as one passage in `ExecRenderBaseCommand` that might cause trouble on buffered consoles. Not yet tried on windows machine yet, dev version working fine so far.

Also relaxed cleanup pattern in `package.json` as my cleanups were incomplete with the given one, confusing me when using dev tools mentioned in contribution guide ( `yarn compile` did not rebuild `dist` after `yarn clean` , took some time to figure out root cause: the `tsconfig.tsbuildinfo` file was still present ).