### PR TITLE
fix(ci): use relative paths for artifact download target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: pkg-tarballs
-          path: /pkg-tarballs
+          path: ./pkg-tarballs
 
       - name: Docker meta
         id: meta
@@ -233,7 +233,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: pkg-tarballs
-          path: /pkg-tarballs
+          path: ./pkg-tarballs
 
       - name: Generate Homebrew formula
         run: |


### PR DESCRIPTION
Well. Hard to test. Not sure if local run would have spotted this even.