### PR TITLE
fix(domain/virtualhost): keep colons in --path-to-url values

### DIFF
--- a/src/commands/domain/virtualhost/create.tsx
+++ b/src/commands/domain/virtualhost/create.tsx
@@ -83,7 +83,8 @@ export default class Create extends ExecRenderBaseCommand<
     }
 
     for (const pathToUrl of this.flags["path-to-url"] ?? []) {
-      const [path, url] = pathToUrl.split(":");
+      const [path, ...urlParts] = pathToUrl.split(":");
+      const url = urlParts.join(":");
       paths.push({ path, target: { url } });
     }
 


### PR DESCRIPTION
Fixes #1879.

`--path-to-url "/:https://example.com"` currently fails with `Target.Url: Does not match format 'uri'` because the value is split on every colon, so `url` ends up as `"https"`.

This change splits on the first colon while preserving the rest:

```ts
const [path, ...urlParts] = pathToUrl.split(":");
const url = urlParts.join(":");
```

`split(":", 2)` would not work in JS — it drops the rest of the string. The destructure + `join` approach keeps the full URL, including any colons inside it (e.g. ports: `https://backend.example.com:8080/v2`).

## Verification

- `yarn compile`, `yarn lint`, prettier — all green.
- `yarn test:unit` (full suite): 121 tests passing, no regressions.
- Manual check of the parser logic against three realistic inputs:

```
/:https://redirect.example                       → path="/",    url="https://redirect.example"
/api:https://backend.example.com:8080/v2         → path="/api", url="https://backend.example.com:8080/v2"
/old:http://example.com                          → path="/old", url="http://example.com"
```

- Verified end-to-end against the live Mittwald API (POST /v2/ingresses) that the resulting payload is accepted and the 301 redirect works.

No new unit test added — this command does not currently have unit-test coverage and the parsing is inline in `exec()`. Happy to extract a helper and add a test if maintainers prefer.