### PR TITLE
feat(stack): show update schedule in stack list

### DIFF
--- a/src/commands/stack/list.ts
+++ b/src/commands/stack/list.ts
@@ -72,6 +72,17 @@ export class List extends ListBaseCommand<typeof List, ListItem, ListResponse> {
           return stack.volumes.length + " volumes";
         },
       },
+      updateSchedule: {
+        header: "Update schedule",
+        get(stack) {
+          if (!stack.updateSchedule) {
+            return "no schedule";
+          }
+
+          const { cron, timezone } = stack.updateSchedule;
+          return timezone ? `${cron} (${timezone})` : cron;
+        },
+      },
     };
   }
 }


### PR DESCRIPTION
## Summary

`mw stack list` now shows the configured update schedule of each container stack in a new **Update schedule** column.

The column reads the `updateSchedule` field from the `ContainerStackResponse`:

- Shows `no schedule` when none is configured.
- Shows the cron expression alone (e.g. `0 3 * * *`) when no timezone is set.
- Shows `cron (timezone)` (e.g. `0 3 * * * (Europe/Berlin)`) when a timezone is present.

The column flows through the existing table formatter, so it also appears in the JSON/CSV output modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)