### PR TITLE
feat(domain): add command to update a virtual host's paths

### DIFF
--- a/docs/domain.md
+++ b/docs/domain.md
@@ -364,8 +364,8 @@ Update the paths of an existing virtual host. The given paths replace the existi
 
 ```
 USAGE
-  $ mw domain virtualhost update VIRTUAL-HOST-ID [--token <value>] [-q] [--path-to-app <value>...] [--path-to-url
-    <value>...] [--path-to-container <value>...]
+  $ mw domain virtualhost update VIRTUAL-HOST-ID [--token <value>] [-q] [--path-to-app <value>...] [--path-to-url <value>...]
+    [--path-to-container <value>...]
 
 ARGUMENTS
   VIRTUAL-HOST-ID  ID of the virtual host to update
@@ -387,7 +387,8 @@ DESCRIPTION
 EXAMPLES
   Point the root path of a virtual host to an app
 
-    $ mw domain virtualhost update 3ecaf1a9-6eb4-4869-b811-8a13c3a2e745 --path-to-app /:fdc7e3a8-9b1c-4d2e-8f5a-6c7b8d9e0f1a
+    $ mw domain virtualhost update 3ecaf1a9-6eb4-4869-b811-8a13c3a2e745 --path-to-app \
+      /:fdc7e3a8-9b1c-4d2e-8f5a-6c7b8d9e0f1a
 
   Point the root path of a virtual host to a URL
 
@@ -418,3 +419,4 @@ FLAG DESCRIPTIONS
     and the external URL, separated by a colon, e.g. /:https://redirect.example. You can specify this flag multiple
     times to map multiple paths to different external URLs, and also combine it with the other --path-to-* flags.
 ```
+

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -12,6 +12,7 @@ Manage domains, virtual hosts and DNS settings in your projects
 * [`mw domain virtualhost delete VIRTUAL-HOST-ID`](#mw-domain-virtualhost-delete-virtual-host-id)
 * [`mw domain virtualhost get INGRESS-ID`](#mw-domain-virtualhost-get-ingress-id)
 * [`mw domain virtualhost list`](#mw-domain-virtualhost-list)
+* [`mw domain virtualhost update VIRTUAL-HOST-ID`](#mw-domain-virtualhost-update-virtual-host-id)
 
 ## `mw domain dnszone get DNSZONE-ID`
 
@@ -356,3 +357,64 @@ FLAG DESCRIPTIONS
     to persistently set a default project for all commands that accept this flag.
 ```
 
+
+## `mw domain virtualhost update VIRTUAL-HOST-ID`
+
+Update the paths of an existing virtual host. The given paths replace the existing ones entirely, so you need to specify all paths that the virtual host should have after the update.
+
+```
+USAGE
+  $ mw domain virtualhost update VIRTUAL-HOST-ID [--token <value>] [-q] [--path-to-app <value>...] [--path-to-url
+    <value>...] [--path-to-container <value>...]
+
+ARGUMENTS
+  VIRTUAL-HOST-ID  ID of the virtual host to update
+
+FLAGS
+  -q, --quiet                         suppress process output and only display a machine-readable summary
+      --path-to-app=<value>...        add a path mapping to an app
+      --path-to-container=<value>...  add a path mapping to a container
+      --path-to-url=<value>...        add a path mapping to an external url
+
+AUTHENTICATION FLAGS
+  --token=<value>  API token to use for authentication (overrides environment and config file). NOTE: watch out that
+                   tokens passed via this flag might be logged in your shell history.
+
+DESCRIPTION
+  Update the paths of an existing virtual host. The given paths replace the existing ones entirely, so you need to
+  specify all paths that the virtual host should have after the update.
+
+EXAMPLES
+  Point the root path of a virtual host to an app
+
+    $ mw domain virtualhost update 3ecaf1a9-6eb4-4869-b811-8a13c3a2e745 --path-to-app /:fdc7e3a8-9b1c-4d2e-8f5a-6c7b8d9e0f1a
+
+  Point the root path of a virtual host to a URL
+
+    $ mw domain virtualhost update 3ecaf1a9-6eb4-4869-b811-8a13c3a2e745 --path-to-url /:https://redirect.example
+
+FLAG DESCRIPTIONS
+  -q, --quiet  suppress process output and only display a machine-readable summary
+
+    This flag controls if you want to see the process output or only a summary. When using mw non-interactively (e.g. in
+    scripts), you can use this flag to easily get the IDs of created resources for further processing.
+
+  --path-to-app=<value>...  add a path mapping to an app
+
+    This flag can be used to map a specific URL path to an app; the value for this flag should be the URL path and the
+    app ID, separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745. You can specify this flag multiple times
+    to map multiple paths to different apps, and also combine it with the other --path-to-* flags.
+
+  --path-to-container=<value>...  add a path mapping to a container
+
+    This flag can be used to map a specific URL path to a container; the value for this flag should be the URL path, the
+    container ID and the target port, each separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745:80/tcp. You
+    can specify this flag multiple times to map multiple paths to different containers, and also combine it with the
+    other --path-to-* flags.
+
+  --path-to-url=<value>...  add a path mapping to an external url
+
+    This flag can be used to map a specific URL path to an external URL; the value for this flag should be the URL path
+    and the external URL, separated by a colon, e.g. /:https://redirect.example. You can specify this flag multiple
+    times to map multiple paths to different external URLs, and also combine it with the other --path-to-* flags.
+```

--- a/src/commands/domain/virtualhost/create.tsx
+++ b/src/commands/domain/virtualhost/create.tsx
@@ -4,6 +4,10 @@ import {
   processFlags,
 } from "../../../rendering/process/process_flags.js";
 import { projectFlags } from "../../../lib/resources/project/flags.js";
+import {
+  buildIngressPaths,
+  pathMappingFlags,
+} from "../../../lib/resources/domain/virtualhost/flags.js";
 import { ReactNode } from "react";
 import { assertStatus } from "@mittwald/api-client-commons";
 import { Flags } from "@oclif/core";
@@ -14,7 +18,6 @@ import { waitUntil } from "../../../lib/wait.js";
 import { Box } from "ink";
 import { DnsValidationErrors } from "../../../rendering/react/components/Ingress/DnsValidationErrors.js";
 
-type IngressPath = MittwaldAPIV2.Components.Schemas.IngressPath;
 type IngressIngress = MittwaldAPIV2.Components.Schemas.IngressIngress;
 
 type CreateResult = {
@@ -51,50 +54,14 @@ export default class Create extends ExecRenderBaseCommand<
       description: "the hostname of the ingress",
       required: true,
     }),
-    "path-to-app": Flags.string({
-      summary: "add a path mapping to an app",
-      description:
-        "This flag can be used to map a specific URL path to an app; the value for this flag should be the URL path and the app ID, separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745. You can specify this flag multiple times to map multiple paths to different apps, and also combine it with the other --path-to-* flags.",
-      multiple: true,
-    }),
-    "path-to-url": Flags.string({
-      summary: "add a path mapping to an external url",
-      multiple: true,
-      description:
-        "This flag can be used to map a specific URL path to an external URL; the value for this flag should be the URL path and the external URL, separated by a colon, e.g. /:https://redirect.example. You can specify this flag multiple times to map multiple paths to different external URLs, and also combine it with the other --path-to-* flags.",
-    }),
-    "path-to-container": Flags.string({
-      summary: "add a path mapping to a container",
-      multiple: true,
-      description:
-        "This flag can be used to map a specific URL path to a container; the value for this flag should be the URL path, the container ID and the target port, each separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745:80/tcp. You can specify this flag multiple times to map multiple paths to different containers, and also combine it with the other --path-to-* flags.",
-    }),
+    ...pathMappingFlags,
   };
 
   protected async exec(): Promise<CreateResult> {
     const projectId = await this.withProjectId(Create);
     const process = makeProcessRenderer(this.flags, "Creating a new ingress");
     const { hostname } = this.flags;
-    const paths: IngressPath[] = [];
-
-    for (const pathToApp of this.flags["path-to-app"] ?? []) {
-      const [path, installationId] = pathToApp.split(":");
-      paths.push({ path, target: { installationId } });
-    }
-
-    for (const pathToUrl of this.flags["path-to-url"] ?? []) {
-      const [path, ...urlParts] = pathToUrl.split(":");
-      const url = urlParts.join(":");
-      paths.push({ path, target: { url } });
-    }
-
-    for (const pathToContainer of this.flags["path-to-container"] ?? []) {
-      const [path, container, portProtocol] = pathToContainer.split(":", 3);
-      paths.push({
-        path,
-        target: { container: { id: container, portProtocol } },
-      });
-    }
+    const paths = buildIngressPaths(this.flags);
 
     const { id: ingressId } = await process.runStep(
       "creating ingress",

--- a/src/commands/domain/virtualhost/update.tsx
+++ b/src/commands/domain/virtualhost/update.tsx
@@ -1,0 +1,139 @@
+import { ExecRenderBaseCommand } from "../../../lib/basecommands/ExecRenderBaseCommand.js";
+import {
+  makeProcessRenderer,
+  processFlags,
+} from "../../../rendering/process/process_flags.js";
+import { ReactNode } from "react";
+import { assertStatus } from "@mittwald/api-client-commons";
+import { Args, Flags, ux } from "@oclif/core";
+import type { MittwaldAPIV2 } from "@mittwald/api-client";
+import { Success } from "../../../rendering/react/components/Success.js";
+import { Value } from "../../../rendering/react/components/Value.js";
+
+type IngressPath = MittwaldAPIV2.Components.Schemas.IngressPath;
+type IngressIngress = MittwaldAPIV2.Components.Schemas.IngressIngress;
+
+type UpdateResult = {
+  ingress: IngressIngress;
+};
+
+export default class Update extends ExecRenderBaseCommand<
+  typeof Update,
+  UpdateResult
+> {
+  static description =
+    "Update the paths of an existing virtual host. The given paths replace the existing ones entirely, so you need to specify all paths that the virtual host should have after the update.";
+  static examples = [
+    {
+      description: "Point the root path of a virtual host to an app",
+      command:
+        "<%= config.bin %> <%= command.id %> 3ecaf1a9-6eb4-4869-b811-8a13c3a2e745 --path-to-app /:fdc7e3a8-9b1c-4d2e-8f5a-6c7b8d9e0f1a",
+    },
+    {
+      description: "Point the root path of a virtual host to a URL",
+      command:
+        "<%= config.bin %> <%= command.id %> 3ecaf1a9-6eb4-4869-b811-8a13c3a2e745 --path-to-url /:https://redirect.example",
+    },
+  ];
+  static args = {
+    "virtual-host-id": Args.string({
+      description: "ID of the virtual host to update",
+      required: true,
+    }),
+  };
+  static flags = {
+    ...processFlags,
+    "path-to-app": Flags.string({
+      summary: "add a path mapping to an app",
+      description:
+        "This flag can be used to map a specific URL path to an app; the value for this flag should be the URL path and the app ID, separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745. You can specify this flag multiple times to map multiple paths to different apps, and also combine it with the other --path-to-* flags.",
+      multiple: true,
+    }),
+    "path-to-url": Flags.string({
+      summary: "add a path mapping to an external url",
+      multiple: true,
+      description:
+        "This flag can be used to map a specific URL path to an external URL; the value for this flag should be the URL path and the external URL, separated by a colon, e.g. /:https://redirect.example. You can specify this flag multiple times to map multiple paths to different external URLs, and also combine it with the other --path-to-* flags.",
+    }),
+    "path-to-container": Flags.string({
+      summary: "add a path mapping to a container",
+      multiple: true,
+      description:
+        "This flag can be used to map a specific URL path to a container; the value for this flag should be the URL path, the container ID and the target port, each separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745:80/tcp. You can specify this flag multiple times to map multiple paths to different containers, and also combine it with the other --path-to-* flags.",
+    }),
+  };
+
+  protected async exec(): Promise<UpdateResult> {
+    const ingressId = this.args["virtual-host-id"];
+    const process = makeProcessRenderer(
+      this.flags,
+      "Updating the paths of a virtual host",
+    );
+    const paths: IngressPath[] = [];
+
+    for (const pathToApp of this.flags["path-to-app"] ?? []) {
+      const [path, installationId] = pathToApp.split(":");
+      paths.push({ path, target: { installationId } });
+    }
+
+    for (const pathToUrl of this.flags["path-to-url"] ?? []) {
+      const [path, ...urlParts] = pathToUrl.split(":");
+      const url = urlParts.join(":");
+      paths.push({ path, target: { url } });
+    }
+
+    for (const pathToContainer of this.flags["path-to-container"] ?? []) {
+      const [path, container, portProtocol] = pathToContainer.split(":", 3);
+      paths.push({
+        path,
+        target: { container: { id: container, portProtocol } },
+      });
+    }
+
+    if (paths.length === 0) {
+      process.error(
+        "You need to specify at least one path mapping using one of the --path-to-* flags.",
+      );
+      ux.exit(1);
+    }
+
+    await process.runStep("updating ingress paths", async () => {
+      const response = await this.apiClient.domain.ingressUpdateIngressPaths({
+        ingressId,
+        data: paths,
+      });
+
+      assertStatus(response, 204);
+    });
+
+    const ingress = await process.runStep(
+      "fetching updated virtual host",
+      async (): Promise<IngressIngress> => {
+        const response = await this.apiClient.domain.ingressGetIngress({
+          ingressId,
+        });
+
+        assertStatus(response, 200);
+
+        return response.data;
+      },
+    );
+
+    await process.complete(
+      <Success>
+        The paths of your virtual host <Value>{ingress.hostname}</Value> were
+        successfully updated! 🚀
+      </Success>,
+    );
+
+    return { ingress };
+  }
+
+  protected render({ ingress }: UpdateResult): ReactNode {
+    if (this.flags.quiet) {
+      this.log(ingress.id);
+    }
+
+    return undefined;
+  }
+}

--- a/src/commands/domain/virtualhost/update.tsx
+++ b/src/commands/domain/virtualhost/update.tsx
@@ -3,14 +3,17 @@ import {
   makeProcessRenderer,
   processFlags,
 } from "../../../rendering/process/process_flags.js";
+import {
+  buildIngressPaths,
+  pathMappingFlags,
+} from "../../../lib/resources/domain/virtualhost/flags.js";
 import { ReactNode } from "react";
 import { assertStatus } from "@mittwald/api-client-commons";
-import { Args, Flags, ux } from "@oclif/core";
+import { Args, ux } from "@oclif/core";
 import type { MittwaldAPIV2 } from "@mittwald/api-client";
 import { Success } from "../../../rendering/react/components/Success.js";
 import { Value } from "../../../rendering/react/components/Value.js";
 
-type IngressPath = MittwaldAPIV2.Components.Schemas.IngressPath;
 type IngressIngress = MittwaldAPIV2.Components.Schemas.IngressIngress;
 
 type UpdateResult = {
@@ -43,24 +46,7 @@ export default class Update extends ExecRenderBaseCommand<
   };
   static flags = {
     ...processFlags,
-    "path-to-app": Flags.string({
-      summary: "add a path mapping to an app",
-      description:
-        "This flag can be used to map a specific URL path to an app; the value for this flag should be the URL path and the app ID, separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745. You can specify this flag multiple times to map multiple paths to different apps, and also combine it with the other --path-to-* flags.",
-      multiple: true,
-    }),
-    "path-to-url": Flags.string({
-      summary: "add a path mapping to an external url",
-      multiple: true,
-      description:
-        "This flag can be used to map a specific URL path to an external URL; the value for this flag should be the URL path and the external URL, separated by a colon, e.g. /:https://redirect.example. You can specify this flag multiple times to map multiple paths to different external URLs, and also combine it with the other --path-to-* flags.",
-    }),
-    "path-to-container": Flags.string({
-      summary: "add a path mapping to a container",
-      multiple: true,
-      description:
-        "This flag can be used to map a specific URL path to a container; the value for this flag should be the URL path, the container ID and the target port, each separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745:80/tcp. You can specify this flag multiple times to map multiple paths to different containers, and also combine it with the other --path-to-* flags.",
-    }),
+    ...pathMappingFlags,
   };
 
   protected async exec(): Promise<UpdateResult> {
@@ -69,26 +55,7 @@ export default class Update extends ExecRenderBaseCommand<
       this.flags,
       "Updating the paths of a virtual host",
     );
-    const paths: IngressPath[] = [];
-
-    for (const pathToApp of this.flags["path-to-app"] ?? []) {
-      const [path, installationId] = pathToApp.split(":");
-      paths.push({ path, target: { installationId } });
-    }
-
-    for (const pathToUrl of this.flags["path-to-url"] ?? []) {
-      const [path, ...urlParts] = pathToUrl.split(":");
-      const url = urlParts.join(":");
-      paths.push({ path, target: { url } });
-    }
-
-    for (const pathToContainer of this.flags["path-to-container"] ?? []) {
-      const [path, container, portProtocol] = pathToContainer.split(":", 3);
-      paths.push({
-        path,
-        target: { container: { id: container, portProtocol } },
-      });
-    }
+    const paths = buildIngressPaths(this.flags);
 
     if (paths.length === 0) {
       process.error(

--- a/src/lib/resources/domain/virtualhost/flags.ts
+++ b/src/lib/resources/domain/virtualhost/flags.ts
@@ -1,0 +1,63 @@
+import { Flags } from "@oclif/core";
+import type { MittwaldAPIV2 } from "@mittwald/api-client";
+
+type IngressPath = MittwaldAPIV2.Components.Schemas.IngressPath;
+
+/**
+ * Flags for mapping URL paths to targets (apps, URLs or containers) of a
+ * virtual host. Shared between the `virtualhost create` and `virtualhost
+ * update` commands.
+ */
+export const pathMappingFlags = {
+  "path-to-app": Flags.string({
+    summary: "add a path mapping to an app",
+    description:
+      "This flag can be used to map a specific URL path to an app; the value for this flag should be the URL path and the app ID, separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745. You can specify this flag multiple times to map multiple paths to different apps, and also combine it with the other --path-to-* flags.",
+    multiple: true,
+  }),
+  "path-to-url": Flags.string({
+    summary: "add a path mapping to an external url",
+    multiple: true,
+    description:
+      "This flag can be used to map a specific URL path to an external URL; the value for this flag should be the URL path and the external URL, separated by a colon, e.g. /:https://redirect.example. You can specify this flag multiple times to map multiple paths to different external URLs, and also combine it with the other --path-to-* flags.",
+  }),
+  "path-to-container": Flags.string({
+    summary: "add a path mapping to a container",
+    multiple: true,
+    description:
+      "This flag can be used to map a specific URL path to a container; the value for this flag should be the URL path, the container ID and the target port, each separated by a colon, e.g. /:3ecaf1a9-6eb4-4869-b811-8a13c3a2e745:80/tcp. You can specify this flag multiple times to map multiple paths to different containers, and also combine it with the other --path-to-* flags.",
+  }),
+};
+
+/**
+ * Builds the list of {@link IngressPath} entries from the values of the
+ * {@link pathMappingFlags}.
+ */
+export function buildIngressPaths(flags: {
+  "path-to-app"?: string[];
+  "path-to-url"?: string[];
+  "path-to-container"?: string[];
+}): IngressPath[] {
+  const paths: IngressPath[] = [];
+
+  for (const pathToApp of flags["path-to-app"] ?? []) {
+    const [path, installationId] = pathToApp.split(":");
+    paths.push({ path, target: { installationId } });
+  }
+
+  for (const pathToUrl of flags["path-to-url"] ?? []) {
+    const [path, ...urlParts] = pathToUrl.split(":");
+    const url = urlParts.join(":");
+    paths.push({ path, target: { url } });
+  }
+
+  for (const pathToContainer of flags["path-to-container"] ?? []) {
+    const [path, container, portProtocol] = pathToContainer.split(":", 3);
+    paths.push({
+      path,
+      target: { container: { id: container, portProtocol } },
+    });
+  }
+
+  return paths;
+}


### PR DESCRIPTION
## Summary

Closes #1952.

`mw domain virtualhost` supported `create` / `delete` / `get` / `list`, but there was no way to **update** the paths of an existing virtual host. Re-pointing a path required a disruptive delete + recreate (dropping the ingress and its cert association) or a hand-rolled API call.

This adds `mw domain virtualhost update VIRTUAL-HOST-ID`, which wraps `PATCH /v2/ingresses/{ingressId}/paths` and lets the path → target mappings of an existing virtual host be edited in place.

## Details

- Reuses the same `--path-to-app` / `--path-to-url` / `--path-to-container` flags accepted by `virtualhost create`, with identical parsing.
- The endpoint replaces the path set entirely, so the command requires at least one path mapping and the description makes clear that the supplied paths fully replace the existing ones.
- After the `PATCH` (204) it re-fetches the ingress to report the updated virtual host; `--quiet` prints the ingress ID for scripting.
- Docs regenerated for the new command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)