### PR TITLE
fix(project): handle inaccessible customer in project get

### DIFF
--- a/src/commands/project/get.tsx
+++ b/src/commands/project/get.tsx
@@ -95,7 +95,6 @@ const GetProject: FC<{ response: ProjectProject }> = ({ response }) => {
     [response.id],
   );
 
-  assertStatus(customer, 200);
   assertStatus(vhosts, 200);
 
   const host = vhosts.data.find((h) => h.isDefault)?.hostname;
@@ -104,7 +103,15 @@ const GetProject: FC<{ response: ProjectProject }> = ({ response }) => {
     "Project ID": <IDAndShortID object={response} />,
     "Created At": <CreatedAt object={response} />,
     Status: <ProjectStatus project={response} />,
-    Customer: <ProjectCustomer customer={customer.data} />,
+    // The user might have access to the project, but not to the customer it
+    // belongs to. In that case, fall back to displaying just the customer ID
+    // instead of failing with a permission error (see #1955).
+    Customer:
+      customer.status === 200 ? (
+        <ProjectCustomer customer={customer.data} />
+      ) : (
+        <Value>{response.customerId}</Value>
+      ),
   };
 
   const sections = [


### PR DESCRIPTION
## Summary

Fixes #1955.

When a user has access to a project but not the customer it belongs to, `mw project get` failed with a `PermissionDenied` error: the customer fetch was asserted to return `200`, and the `403` threw before any project information could be rendered.

This change removes the assertion on the customer fetch and renders the Customer row conditionally — the full customer table when accessible, otherwise a graceful fallback showing just the customer ID (which is always present on the project response). The project's own details are now always displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)