### PR TITLE
feat(experimental/deploy): make image and service name configurable

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -33,27 +33,21 @@ AUTHENTICATION FLAGS
                    tokens passed via this flag might be logged in your shell history.
 
 EXAMPLES
-  Deploy from current directory (auto-detects or creates Dockerfile):
+  Deploy from current directory (auto-detects or creates Dockerfile)
 
-    $ mw deploy
+    $ mw experimental deploy
 
+  Deploy with explicit project context
 
+    $ mw experimental deploy --project-id p-abc123
 
-  Deploy with explicit project context:
+  Deploy with custom default domain prefix
 
-    $ mw deploy --project-id p-abc123
+    $ mw experimental deploy --uri-prefix myapp
 
+  Deploy a second, parallel service with a custom image and service name
 
-
-  Deploy with custom default domain prefix:
-
-    $ mw deploy --uri-prefix myapp
-
-
-
-  Deploy a second, parallel service with a custom image and service name:
-
-    $ mw deploy --service-name my-feature --image-name my-app --image-tag feature
+    $ mw experimental deploy --service-name my-feature --image-name my-app --image-tag feature
 
 FLAG DESCRIPTIONS
   -e, --env=<value>...  set environment variables in the container

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -12,7 +12,7 @@ Deploys a new container.
 ```
 USAGE
   $ mw experimental deploy [--token <value>] [-q] [-p <value>] [-w] [--wait-timeout <value>] [-e <value>...] [--env-file
-    <value>...] [--uri-prefix <value>]
+    <value>...] [--uri-prefix <value>] [--service-name <value>] [--image-name <value>] [--image-tag <value>]
 
 FLAGS
   -e, --env=<value>...        set environment variables in the container
@@ -21,6 +21,9 @@ FLAGS
   -q, --quiet                 suppress process output and only display a machine-readable summary
   -w, --wait                  wait for the resource to be ready.
       --env-file=<value>...   read environment variables from a file
+      --image-name=<value>    name of the Docker image to build and push
+      --image-tag=<value>     tag of the Docker image to build and push
+      --service-name=<value>  name of the container service to deploy
       --uri-prefix=<value>    [default: webapp] prefix for the generated default domain
       --wait-timeout=<value>  [default: 600s] the duration to wait for the resource to be ready (common units like 'ms',
                               's', 'm' are accepted).
@@ -46,6 +49,12 @@ EXAMPLES
 
     $ mw deploy --uri-prefix myapp
 
+
+
+  Deploy a second, parallel service with a custom image and service name:
+
+    $ mw deploy --service-name my-feature --image-name my-app --image-tag feature
+
 FLAG DESCRIPTIONS
   -e, --env=<value>...  set environment variables in the container
 
@@ -65,6 +74,18 @@ FLAG DESCRIPTIONS
 
     The file should contain lines in the format KEY=VALUE. Multiple files can be specified with multiple --env-file
     flags.
+
+  --image-name=<value>  name of the Docker image to build and push
+
+    Defaults to 'app-image'.
+
+  --image-tag=<value>  tag of the Docker image to build and push
+
+    Defaults to 'latest'.
+
+  --service-name=<value>  name of the container service to deploy
+
+    Set this to run multiple parallel deployments in the same project. Defaults to 'app-<project-id>'.
 
   --uri-prefix=<value>  prefix for the generated default domain
 

--- a/src/commands/experimental/deploy.tsx
+++ b/src/commands/experimental/deploy.tsx
@@ -77,17 +77,25 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
   };
   static args = {};
   static examples = [
-    "Deploy from current directory (auto-detects or creates Dockerfile):",
-    "  $ mw deploy",
-    "",
-    "Deploy with explicit project context:",
-    "  $ mw deploy --project-id p-abc123",
-    "",
-    "Deploy with custom default domain prefix:",
-    "  $ mw deploy --uri-prefix myapp",
-    "",
-    "Deploy a second, parallel service with a custom image and service name:",
-    "  $ mw deploy --service-name my-feature --image-name my-app --image-tag feature",
+    {
+      description:
+        "Deploy from current directory (auto-detects or creates Dockerfile)",
+      command: "$ <%= config.bin %> <%= command.id %>",
+    },
+    {
+      description: "Deploy with explicit project context",
+      command: "<%= config.bin %> <%= command.id %> --project-id p-abc123",
+    },
+    {
+      description: "Deploy with custom default domain prefix",
+      command: "<%= config.bin %> <%= command.id %> --uri-prefix myapp",
+    },
+    {
+      description:
+        "Deploy a second, parallel service with a custom image and service name",
+      command:
+        "<%= config.bin %> <%= command.id %> --service-name my-feature --image-name my-app --image-tag feature",
+    },
   ];
 
   protected async exec(): Promise<Result> {

--- a/src/commands/experimental/deploy.tsx
+++ b/src/commands/experimental/deploy.tsx
@@ -21,6 +21,8 @@ import {
   localDockerPush,
   deployService,
   createAndWaitForDomain,
+  DEFAULT_IMAGE_NAME,
+  DEFAULT_IMAGE_TAG,
 } from "@mittwald/container-deploy";
 
 type Result = {
@@ -56,6 +58,22 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
       required: false,
       default: "webapp",
     }),
+    "service-name": Flags.string({
+      summary: "name of the container service to deploy",
+      description:
+        "Set this to run multiple parallel deployments in the same project. Defaults to 'app-<project-id>'.",
+      required: false,
+    }),
+    "image-name": Flags.string({
+      summary: "name of the Docker image to build and push",
+      description: `Defaults to '${DEFAULT_IMAGE_NAME}'.`,
+      required: false,
+    }),
+    "image-tag": Flags.string({
+      summary: "tag of the Docker image to build and push",
+      description: `Defaults to '${DEFAULT_IMAGE_TAG}'.`,
+      required: false,
+    }),
   };
   static args = {};
   static examples = [
@@ -67,6 +85,9 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
     "",
     "Deploy with custom default domain prefix:",
     "  $ mw deploy --uri-prefix myapp",
+    "",
+    "Deploy a second, parallel service with a custom image and service name:",
+    "  $ mw deploy --service-name my-feature --image-name my-app --image-tag feature",
   ];
 
   protected async exec(): Promise<Result> {
@@ -119,7 +140,10 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
     const builtImage = await p.runStep(
       "Building Docker image ...",
       async () => {
-        const result = await buildDockerImage(registryData, repositoryData);
+        const result = await buildDockerImage(registryData, repositoryData, {
+          name: this.flags["image-name"],
+          tag: this.flags["image-tag"],
+        });
         p.addInfo(`Built image ${result.imageName}`);
         return result;
       },
@@ -137,6 +161,7 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
         repositoryData,
         this.flags["wait-timeout"],
         environment,
+        this.flags["service-name"],
       );
       deployedServiceId = result.deployedServiceId;
       p.addInfo(`Service ${result.serviceName} is now running`);


### PR DESCRIPTION
## Summary

Extends `mw experimental deploy` with `--service-name`, `--image-name` and `--image-tag` flags so multiple parallel deployments can run within the same project. Each flag falls back to a sensible default when omitted:

- `--service-name` → `app-<project-id>`
- `--image-name` → `app-image`
- `--image-tag` → `latest`

The flags are wired through to `buildDockerImage` (image options) and `deployService` (service name) from `@mittwald/container-deploy`.

Closes #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)