### PR TITLE
docs(app): note admin password complexity policy on --admin-pass

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -760,6 +760,8 @@ FLAG DESCRIPTIONS
   --admin-pass=<value>  password of your administrator user.
 
     The password that will be used for the first administrator user that is created during the Contao installation.
+    The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a
+    password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
     If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after
     the installation is finished
 
@@ -863,6 +865,8 @@ FLAG DESCRIPTIONS
   --admin-pass=<value>  password of your administrator user.
 
     The password that will be used for the first administrator user that is created during the Joomla! installation.
+    The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a
+    password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
     If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after
     the installation is finished
 
@@ -951,6 +955,8 @@ FLAG DESCRIPTIONS
   --admin-pass=<value>  password of your administrator user.
 
     The password that will be used for the first administrator user that is created during the Matomo installation.
+    The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a
+    password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
     If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after
     the installation is finished
 
@@ -1040,6 +1046,8 @@ FLAG DESCRIPTIONS
   --admin-pass=<value>  password of your administrator user.
 
     The password that will be used for the first administrator user that is created during the Nextcloud installation.
+    The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a
+    password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
     If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after
     the installation is finished
 
@@ -1148,6 +1156,8 @@ FLAG DESCRIPTIONS
   --admin-pass=<value>  password of your administrator user.
 
     The password that will be used for the first administrator user that is created during the Shopware 5 installation.
+    The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a
+    password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
     If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after
     the installation is finished
 
@@ -1273,6 +1283,8 @@ FLAG DESCRIPTIONS
   --admin-pass=<value>  password of your administrator user.
 
     The password that will be used for the first administrator user that is created during the Shopware 6 installation.
+    The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a
+    password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
     If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after
     the installation is finished
 
@@ -1380,6 +1392,8 @@ FLAG DESCRIPTIONS
   --admin-pass=<value>  password of your administrator user.
 
     The password that will be used for the first administrator user that is created during the TYPO3 installation.
+    The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a
+    password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
     If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after
     the installation is finished
 
@@ -1475,6 +1489,8 @@ FLAG DESCRIPTIONS
   --admin-pass=<value>  password of your administrator user.
 
     The password that will be used for the first administrator user that is created during the WordPress installation.
+    The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a
+    password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
     If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after
     the installation is finished
 

--- a/src/lib/resources/app/flags.tsx
+++ b/src/lib/resources/app/flags.tsx
@@ -107,6 +107,7 @@ function buildFlagsWithDescription(appName: string): AvailableFlags {
       required: false,
       summary: "password of your administrator user.",
       description: `The password that will be used for the first administrator user that is created during the ${appName} installation.
+      The password must satisfy the platform's password-complexity policy, which may vary depending on the application; a password that is too weak (for example too short, or missing a mix of character types) may be rejected by the API.
       If unspecified, a random secure password will be generated and printed to stdout. This password can be changed after the installation is finished`,
       default: undefined,
     }),


### PR DESCRIPTION
Amends the `--admin-pass` flag help for `mw app install` to note that the administrator password must satisfy the platform's password-complexity policy — which may vary depending on the application — so a password that is too weak may be rejected by the API.

This is intentionally non-authoritative: the exact rules differ per application, so no specific length or character-class requirements are claimed.

Closes #1968