### PR TITLE
fix(cronjob): include container (service) cronjobs in list

### DIFF
--- a/src/commands/cronjob/list.ts
+++ b/src/commands/cronjob/list.ts
@@ -25,7 +25,10 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
 
   public async getData(): Promise<Response> {
     const projectId = await this.withProjectId(List);
-    return await this.apiClient.cronjob.listCronjobs({ projectId });
+    return await this.apiClient.cronjob.listCronjobs({
+      projectId,
+      queryParameters: { includeServiceCronjobs: true },
+    });
   }
 
   protected getColumns(data: ResponseItem[]): ListColumns<ResponseItem> {


### PR DESCRIPTION
## Summary

`mw cronjob list` did not return cronjobs belonging to containers, because the [cronjob list API](https://developer.mittwald.de/docs/v2/reference/cronjob/cronjob-list-cronjobs/) excludes service cronjobs by default.

This passes `includeServiceCronjobs: true` in the query parameters so container/service cronjobs are listed as well.

Fixes #1980

🤖 Generated with [Claude Code](https://claude.com/claude-code)