### PR TITLE
fix(cronjob): render container cron jobs in "cronjob get"

### DIFF
--- a/src/rendering/react/components/CronJob/CronJobDetails.tsx
+++ b/src/rendering/react/components/CronJob/CronJobDetails.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, ReactNode } from "react";
 import type { MittwaldAPIV2 } from "@mittwald/api-client";
 import { SingleResult } from "../SingleResult.js";
 import { Value } from "../Value.js";
@@ -12,8 +12,20 @@ type CronjobCronjob = MittwaldAPIV2.Components.Schemas.CronjobCronjob;
 type CronjobCronjobUrl = MittwaldAPIV2.Components.Schemas.CronjobCronjobUrl;
 type CronjobCronjobCommand =
   MittwaldAPIV2.Components.Schemas.CronjobCronjobCommand;
+type CronjobServiceTargetResponse =
+  MittwaldAPIV2.Components.Schemas.CronjobServiceTargetResponse;
 
 type CronJobComponent = FC<{ cronjob: CronjobCronjob }>;
+
+// A cron job either targets an app installation or a container (a service
+// running in a stack). Container cron jobs carry a service target instead of
+// an app id, so we must not try to resolve them as app installations.
+const getServiceTarget = (
+  cronjob: CronjobCronjob,
+): CronjobServiceTargetResponse | undefined => {
+  const { target } = cronjob;
+  return target && "stackId" in target ? target : undefined;
+};
 
 const CronJobNextExecution: CronJobComponent = ({ cronjob }) => {
   if (!cronjob.nextExecutionTime) {
@@ -24,6 +36,26 @@ const CronJobNextExecution: CronJobComponent = ({ cronjob }) => {
     <Value>
       <FormattedDate relative date={cronjob.nextExecutionTime} />
     </Value>
+  );
+};
+
+const CronJobAppTarget: FC<{ appInstallationId: string }> = ({
+  appInstallationId,
+}) => {
+  const app = useAppInstallation(appInstallationId);
+  return <IDAndShortID object={app} />;
+};
+
+const CronJobExecutionTargetContainer: FC<{
+  target: CronjobServiceTargetResponse;
+}> = ({ target }) => {
+  return (
+    <SingleResult
+      title="EXECUTION TARGET"
+      rows={{
+        Command: <Value>{target.command}</Value>,
+      }}
+    />
   );
 };
 
@@ -61,13 +93,24 @@ const CronJobExecutionTargetCommand: FC<{ command: CronjobCronjobCommand }> = ({
 
 export const CronJobDetails: CronJobComponent = ({ cronjob }) => {
   const project = cronjob.projectId ? useProject(cronjob.projectId) : null;
-  const app = useAppInstallation(cronjob.appId);
+  const serviceTarget = getServiceTarget(cronjob);
 
-  const rows = {
+  const rows: Record<string, ReactNode> = {
     "Cron Job ID": <IDAndShortID object={cronjob} />,
     "Created At": <CreatedAt object={cronjob} />,
     Project: project ? <IDAndShortID object={project} /> : <Value notSet />,
-    App: <IDAndShortID object={app} />,
+    ...(serviceTarget
+      ? {
+          Stack: <Value>{serviceTarget.stackId}</Value>,
+          Container: <Value>{serviceTarget.serviceShortId}</Value>,
+        }
+      : {
+          App: (
+            <CronJobAppTarget
+              appInstallationId={cronjob.appInstallationId ?? cronjob.appId}
+            />
+          ),
+        }),
     Schedule: (
       <Text>
         <Value>{cronjob.interval}</Value> (next execution:{" "}
@@ -89,7 +132,14 @@ export const CronJobDetails: CronJobComponent = ({ cronjob }) => {
     />,
   ];
 
-  if (cronjob.destination && "url" in cronjob.destination) {
+  if (serviceTarget) {
+    sections.push(
+      <CronJobExecutionTargetContainer
+        key="destination"
+        target={serviceTarget}
+      />,
+    );
+  } else if (cronjob.destination && "url" in cronjob.destination) {
     sections.push(
       <CronJobExecutionTargetURL
         key="destination"

--- a/src/rendering/react/components/CronJob/CronJobDetails.tsx
+++ b/src/rendering/react/components/CronJob/CronJobDetails.tsx
@@ -9,9 +9,6 @@ import { useProject } from "../../../../lib/resources/project/hooks.js";
 import { useAppInstallation } from "../../../../lib/resources/app/hooks.js";
 import { FormattedDate } from "../FormattedDate.js";
 type CronjobCronjob = MittwaldAPIV2.Components.Schemas.CronjobCronjob;
-type CronjobCronjobUrl = MittwaldAPIV2.Components.Schemas.CronjobCronjobUrl;
-type CronjobCronjobCommand =
-  MittwaldAPIV2.Components.Schemas.CronjobCronjobCommand;
 type CronjobServiceTargetResponse =
   MittwaldAPIV2.Components.Schemas.CronjobServiceTargetResponse;
 
@@ -46,49 +43,48 @@ const CronJobAppTarget: FC<{ appInstallationId: string }> = ({
   return <IDAndShortID object={app} />;
 };
 
-const CronJobExecutionTargetContainer: FC<{
-  target: CronjobServiceTargetResponse;
-}> = ({ target }) => {
-  return (
-    <SingleResult
-      title="EXECUTION TARGET"
-      rows={{
-        Command: <Value>{target.command}</Value>,
-      }}
-    />
-  );
-};
+// Rows describing where and how the cron job is executed. For container cron
+// jobs this is the stack/container running the command; for app cron jobs it
+// is the app installation together with the invoked URL or command.
+const buildExecutionTargetRows = (
+  cronjob: CronjobCronjob,
+  serviceTarget: CronjobServiceTargetResponse | undefined,
+): Record<string, ReactNode> => {
+  if (serviceTarget) {
+    return {
+      Stack: <Value>{serviceTarget.stackId}</Value>,
+      Container: <Value>{serviceTarget.serviceShortId}</Value>,
+      Command: <Value>{serviceTarget.command}</Value>,
+    };
+  }
 
-const CronJobExecutionTargetURL: FC<{ dest: CronjobCronjobUrl }> = ({
-  dest,
-}) => {
-  return (
-    <SingleResult
-      title="EXECUTION TARGET"
-      rows={{
-        URL: <Value>{dest.url}</Value>,
-      }}
+  const app = (
+    <CronJobAppTarget
+      appInstallationId={cronjob.appInstallationId ?? cronjob.appId}
     />
   );
-};
 
-const CronJobExecutionTargetCommand: FC<{ command: CronjobCronjobCommand }> = ({
-  command,
-}) => {
-  return (
-    <SingleResult
-      title="EXECUTION TARGET"
-      rows={{
-        Interpreter: <Value>{command.interpreter}</Value>,
-        Script: <Value>{command.path}</Value>,
-        Parameters: command.parameters ? (
-          <Value>{command.parameters} </Value>
-        ) : (
-          <Value notSet />
-        ),
-      }}
-    />
-  );
+  const { destination } = cronjob;
+  if (destination && "url" in destination) {
+    return {
+      App: app,
+      URL: <Value>{destination.url}</Value>,
+    };
+  }
+  if (destination) {
+    return {
+      App: app,
+      Interpreter: <Value>{destination.interpreter}</Value>,
+      Script: <Value>{destination.path}</Value>,
+      Parameters: destination.parameters ? (
+        <Value>{destination.parameters} </Value>
+      ) : (
+        <Value notSet />
+      ),
+    };
+  }
+
+  return { App: app };
 };
 
 export const CronJobDetails: CronJobComponent = ({ cronjob }) => {
@@ -99,18 +95,6 @@ export const CronJobDetails: CronJobComponent = ({ cronjob }) => {
     "Cron Job ID": <IDAndShortID object={cronjob} />,
     "Created At": <CreatedAt object={cronjob} />,
     Project: project ? <IDAndShortID object={project} /> : <Value notSet />,
-    ...(serviceTarget
-      ? {
-          Stack: <Value>{serviceTarget.stackId}</Value>,
-          Container: <Value>{serviceTarget.serviceShortId}</Value>,
-        }
-      : {
-          App: (
-            <CronJobAppTarget
-              appInstallationId={cronjob.appInstallationId ?? cronjob.appId}
-            />
-          ),
-        }),
     Schedule: (
       <Text>
         <Value>{cronjob.interval}</Value> (next execution:{" "}
@@ -120,44 +104,20 @@ export const CronJobDetails: CronJobComponent = ({ cronjob }) => {
     Timezone: <Value>{cronjob.timeZone || "UTC"}</Value>,
   };
 
-  const sections = [
-    <SingleResult
-      key="primary"
-      title={
-        <>
-          CRON JOB DETAILS: <Value>{cronjob.description}</Value>
-        </>
-      }
-      rows={rows}
-    />,
-  ];
-
-  if (serviceTarget) {
-    sections.push(
-      <CronJobExecutionTargetContainer
-        key="destination"
-        target={serviceTarget}
-      />,
-    );
-  } else if (cronjob.destination && "url" in cronjob.destination) {
-    sections.push(
-      <CronJobExecutionTargetURL
-        key="destination"
-        dest={cronjob.destination}
-      />,
-    );
-  } else if (cronjob.destination) {
-    sections.push(
-      <CronJobExecutionTargetCommand
-        key="destination"
-        command={cronjob.destination}
-      />,
-    );
-  }
-
   return (
     <Box flexDirection="column" marginBottom={1}>
-      {sections}
+      <SingleResult
+        title={
+          <>
+            CRON JOB DETAILS: <Value>{cronjob.description}</Value>
+          </>
+        }
+        rows={rows}
+      />
+      <SingleResult
+        title="EXECUTION TARGET"
+        rows={buildExecutionTargetRows(cronjob, serviceTarget)}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

Follow-up to #1981 (container cron job support in `cronjob list`).

A cron job may target an **app installation** OR a **container** (a service running in a stack). `mw cronjob get` previously always resolved the cron job's app installation (`useAppInstallation(cronjob.appId)`), which fails or renders misleading output for container cron jobs.

`CronJobDetails` now branches on the cron job's `target`:

- **Container (service) targets** — show the **Stack** and **Container** instead of an App, and render the container **command** as the execution target.
- **App targets** — rendered as before (via `appInstallationId`, falling back to the deprecated `appId`).

Because the app-installation lookup now lives in a dedicated subcomponent, it is only performed for app cron jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)