### PR TITLE
feat(database): add "database mysql upgrade" command

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -14,6 +14,7 @@ Manage databases (like MySQL and Redis) in your projects
 * [`mw database mysql phpmyadmin DATABASE-ID`](#mw-database-mysql-phpmyadmin-database-id)
 * [`mw database mysql port-forward DATABASE-ID`](#mw-database-mysql-port-forward-database-id)
 * [`mw database mysql shell DATABASE-ID`](#mw-database-mysql-shell-database-id)
+* [`mw database mysql upgrade DATABASE-ID`](#mw-database-mysql-upgrade-database-id)
 * [`mw database mysql user create`](#mw-database-mysql-user-create)
 * [`mw database mysql user delete USER-ID`](#mw-database-mysql-user-delete-user-id)
 * [`mw database mysql user get ID`](#mw-database-mysql-user-get-id)
@@ -567,6 +568,60 @@ FLAG DESCRIPTIONS
     will be used for this.
 
     You can also set this value by setting the MITTWALD_SSH_USER environment variable.
+```
+
+
+## `mw database mysql upgrade DATABASE-ID`
+
+Upgrade a MySQL database to a newer version
+
+```
+USAGE
+  $ mw database mysql upgrade DATABASE-ID [--token <value>] [--version <value>] [-f] [-q] [-w] [--wait-timeout <value>]
+
+ARGUMENTS
+  DATABASE-ID  The ID or name of the database
+
+FLAGS
+  -f, --force                 do not ask for confirmation
+  -q, --quiet                 suppress process output and only display a machine-readable summary
+  -w, --wait                  wait for the resource to be ready.
+      --version=<value>       the MySQL version to upgrade to
+      --wait-timeout=<value>  [default: 600s] the duration to wait for the resource to be ready (common units like 'ms',
+                              's', 'm' are accepted).
+
+AUTHENTICATION FLAGS
+  --token=<value>  API token to use for authentication (overrides environment and config file). NOTE: watch out that
+                   tokens passed via this flag might be logged in your shell history.
+
+DESCRIPTION
+  Upgrade a MySQL database to a newer version
+
+  MySQL does not support downgrades, so only versions newer than the one the database is currently running can be
+  selected. If the target version is omitted, it will be prompted for interactively.
+
+  Upgrading a database is disruptive; the database will be unavailable while the upgrade is running. Consider creating a
+  backup ("mw backup create") before upgrading.
+
+EXAMPLES
+  Upgrade a database to a specific version
+
+    $ mw database mysql upgrade <database-id> --version 8.0
+
+  Upgrade a database to the latest available version, and wait for the upgrade to complete
+
+    $ mw database mysql upgrade <database-id> --version latest --wait
+
+FLAG DESCRIPTIONS
+  -q, --quiet  suppress process output and only display a machine-readable summary
+
+    This flag controls if you want to see the process output or only a summary. When using mw non-interactively (e.g. in
+    scripts), you can use this flag to easily get the IDs of created resources for further processing.
+
+  --version=<value>  the MySQL version to upgrade to
+
+    Use the "database mysql versions" command to list available versions. If set to "latest", the most recent version
+    available for this database will be used.
 ```
 
 

--- a/src/commands/database/mysql/upgrade.tsx
+++ b/src/commands/database/mysql/upgrade.tsx
@@ -1,0 +1,201 @@
+import { ExecRenderBaseCommand } from "../../../lib/basecommands/ExecRenderBaseCommand.js";
+import {
+  mysqlArgs,
+  withMySQLId,
+} from "../../../lib/resources/database/mysql/flags.js";
+import {
+  getUpgradeCandidatesForVersion,
+  compareVersions,
+} from "../../../lib/resources/database/mysql/versions.js";
+import {
+  makeProcessRenderer,
+  processFlags,
+} from "../../../rendering/process/process_flags.js";
+import { ProcessRenderer } from "../../../rendering/process/process.js";
+import { Success } from "../../../rendering/react/components/Success.js";
+import { Value } from "../../../rendering/react/components/Value.js";
+import { waitFlags, waitUntil } from "../../../lib/wait.js";
+import { Flags, ux } from "@oclif/core";
+import { Text } from "ink";
+import { ReactNode } from "react";
+import { MittwaldAPIV2 } from "@mittwald/api-client";
+import { assertStatus } from "@mittwald/api-client-commons";
+
+type Database = MittwaldAPIV2.Components.Schemas.DatabaseMySqlDatabase;
+type MySqlVersion = MittwaldAPIV2.Components.Schemas.DatabaseMySqlVersion;
+
+export class Upgrade extends ExecRenderBaseCommand<typeof Upgrade, void> {
+  static summary = "Upgrade a MySQL database to a newer version";
+  static description = `\
+MySQL does not support downgrades, so only versions newer than the one the database is currently running can be selected. If the target version is omitted, it will be prompted for interactively.
+
+Upgrading a database is disruptive; the database will be unavailable while the upgrade is running. Consider creating a backup ("mw backup create") before upgrading.`;
+
+  static args = { ...mysqlArgs };
+  static flags = {
+    version: Flags.string({
+      summary: "the MySQL version to upgrade to",
+      description:
+        'Use the "database mysql versions" command to list available versions. If set to "latest", the most recent version available for this database will be used.',
+    }),
+    force: Flags.boolean({
+      char: "f",
+      summary: "do not ask for confirmation",
+    }),
+    ...processFlags,
+    ...waitFlags,
+  };
+
+  static examples = [
+    {
+      description: "Upgrade a database to a specific version",
+      command:
+        "<%= config.bin %> database mysql upgrade <database-id> --version 8.0",
+    },
+    {
+      description:
+        "Upgrade a database to the latest available version, and wait for the upgrade to complete",
+      command:
+        "<%= config.bin %> database mysql upgrade <database-id> --version latest --wait",
+    },
+  ];
+
+  protected async exec(): Promise<void> {
+    const p = makeProcessRenderer(this.flags, "Upgrading a MySQL database");
+    const mysqlDatabaseId = await withMySQLId(
+      this.apiClient,
+      this.flags,
+      this.args,
+    );
+
+    const database = await p.runStep("fetching database", async () => {
+      const response = await this.apiClient.database.getMysqlDatabase({
+        mysqlDatabaseId,
+      });
+      assertStatus(response, 200);
+      return response.data;
+    });
+
+    const candidates = await p.runStep("fetching available versions", () =>
+      getUpgradeCandidatesForVersion(this.apiClient, database.version),
+    );
+
+    if (candidates.length === 0) {
+      await p.complete(
+        <Text>
+          The database <Value>{database.name}</Value> already runs the latest
+          available version (<Value>{database.version}</Value>). ✅
+        </Text>,
+      );
+      return;
+    }
+
+    const targetVersion = await this.determineTargetVersion(p, candidates);
+
+    if (!this.flags.force) {
+      const confirmed = await p.addConfirmation(
+        `Confirm upgrading ${database.name} (${database.description}) from version ${database.version} to ${targetVersion.number}`,
+      );
+
+      if (!confirmed) {
+        p.addInfo("Upgrade will not be triggered.");
+        await p.complete(<></>);
+        ux.exit(1);
+      }
+    }
+
+    await p.runStep("triggering upgrade", async () => {
+      const response = await this.apiClient.database.patchMysqlDatabase({
+        mysqlDatabaseId,
+        data: { version: targetVersion.number },
+      });
+      assertStatus(response, 204);
+    });
+
+    if (this.flags.wait) {
+      await this.waitUntilUpgraded(p, mysqlDatabaseId, targetVersion);
+      await p.complete(
+        <Success>
+          The database <Value>{database.name}</Value> was upgraded to version{" "}
+          <Value>{targetVersion.number}</Value>.
+        </Success>,
+      );
+      return;
+    }
+
+    await p.complete(
+      <Success>
+        The upgrade of <Value>{database.name}</Value> to version{" "}
+        <Value>{targetVersion.number}</Value> has been started.
+      </Success>,
+    );
+  }
+
+  private async determineTargetVersion(
+    p: ProcessRenderer,
+    candidates: MySqlVersion[],
+  ): Promise<MySqlVersion> {
+    const requested = this.flags.version;
+
+    if (requested === "latest") {
+      return candidates.sort(compareVersions)[candidates.length - 1];
+    }
+
+    if (requested) {
+      const match = candidates.find((c) => c.number === requested);
+      if (match) {
+        return match;
+      }
+
+      p.error(
+        new Error(
+          `"${requested}" is not a valid upgrade target for this database; available versions are: ${candidates
+            .map((c) => c.number)
+            .join(", ")}`,
+        ),
+      );
+      ux.exit(1);
+    }
+
+    return await p.addSelect(
+      "Please select the version to upgrade to",
+      candidates.map((c) => ({ value: c, label: c.number })),
+    );
+  }
+
+  /**
+   * The API reports a single `version` field rather than a current/desired
+   * pair, so the upgrade is considered done once the database reports the
+   * target version and has left the transitional states.
+   */
+  private async waitUntilUpgraded(
+    p: ProcessRenderer,
+    mysqlDatabaseId: string,
+    targetVersion: MySqlVersion,
+  ): Promise<void> {
+    const step = p.addStep("waiting for the upgrade to complete");
+
+    await waitUntil<Database>(async () => {
+      const response = await this.apiClient.database.getMysqlDatabase({
+        mysqlDatabaseId,
+      });
+
+      if (
+        response.status === 200 &&
+        response.data.version === targetVersion.number &&
+        response.data.status === "ready" &&
+        response.data.isReady
+      ) {
+        return response.data;
+      }
+
+      return null;
+    }, this.flags["wait-timeout"]);
+
+    step.complete();
+  }
+
+  protected render(): ReactNode {
+    return true;
+  }
+}

--- a/src/commands/database/mysql/upgrade.tsx
+++ b/src/commands/database/mysql/upgrade.tsx
@@ -7,6 +7,7 @@ import {
   getUpgradeCandidatesForVersion,
   compareVersions,
 } from "../../../lib/resources/database/mysql/versions.js";
+import { isUpgradeComplete } from "../../../lib/resources/database/mysql/upgrade.js";
 import {
   makeProcessRenderer,
   processFlags,
@@ -113,7 +114,12 @@ Upgrading a database is disruptive; the database will be unavailable while the u
     });
 
     if (this.flags.wait) {
-      await this.waitUntilUpgraded(p, mysqlDatabaseId, targetVersion);
+      await this.waitUntilUpgraded(
+        p,
+        mysqlDatabaseId,
+        targetVersion,
+        database.statusSetAt,
+      );
       await p.complete(
         <Success>
           The database <Value>{database.name}</Value> was upgraded to version{" "}
@@ -163,15 +169,11 @@ Upgrading a database is disruptive; the database will be unavailable while the u
     );
   }
 
-  /**
-   * The API reports a single `version` field rather than a current/desired
-   * pair, so the upgrade is considered done once the database reports the
-   * target version and has left the transitional states.
-   */
   private async waitUntilUpgraded(
     p: ProcessRenderer,
     mysqlDatabaseId: string,
     targetVersion: MySqlVersion,
+    statusSetAtBeforeUpgrade: string,
   ): Promise<void> {
     const step = p.addStep("waiting for the upgrade to complete");
 
@@ -182,9 +184,11 @@ Upgrading a database is disruptive; the database will be unavailable while the u
 
       if (
         response.status === 200 &&
-        response.data.version === targetVersion.number &&
-        response.data.status === "ready" &&
-        response.data.isReady
+        isUpgradeComplete(
+          response.data,
+          targetVersion.number,
+          statusSetAtBeforeUpgrade,
+        )
       ) {
         return response.data;
       }

--- a/src/lib/resources/database/mysql/upgrade.test.ts
+++ b/src/lib/resources/database/mysql/upgrade.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "@jest/globals";
+import { isUpgradeComplete } from "./upgrade.js";
+import { MittwaldAPIV2 } from "@mittwald/api-client";
+
+type Database = MittwaldAPIV2.Components.Schemas.DatabaseMySqlDatabase;
+type DatabaseStatus = MittwaldAPIV2.Components.Schemas.DatabaseDatabaseStatus;
+
+const statusSetAtBefore = "2024-01-01T00:00:00Z";
+
+function database(overrides: {
+  version: string;
+  status: DatabaseStatus;
+  statusSetAt: string;
+}): Database {
+  return {
+    id: "83e0cb85-dcf7-4968-8646-87a63980ae91",
+    name: "mysql_demo",
+    description: "Demo DB",
+    projectId: "p1",
+    isReady: overrides.status === "ready",
+    isShared: false,
+    hostname: "h",
+    externalHostname: "eh",
+    createdAt: statusSetAtBefore,
+    updatedAt: statusSetAtBefore,
+    storageUsageInBytes: 1,
+    storageUsageInBytesSetAt: statusSetAtBefore,
+    characterSettings: {
+      characterSet: "utf8mb4",
+      collation: "utf8mb4_unicode_ci",
+    },
+    ...overrides,
+  };
+}
+
+describe("isUpgradeComplete", () => {
+  it("is not complete while the status still reflects the state from before the upgrade", () => {
+    // The API updates `version` to the desired value as soon as the patch is
+    // accepted, while the status briefly still reads "ready" from before the
+    // upgrade. Treating this as complete would return before the upgrade even
+    // starts.
+    const stale = database({
+      version: "8.4",
+      status: "ready",
+      statusSetAt: statusSetAtBefore,
+    });
+
+    expect(isUpgradeComplete(stale, "8.4", statusSetAtBefore)).toBe(false);
+  });
+
+  it("is not complete while the database is pending", () => {
+    const pending = database({
+      version: "8.4",
+      status: "pending",
+      statusSetAt: "2024-01-01T00:00:05Z",
+    });
+
+    expect(isUpgradeComplete(pending, "8.4", statusSetAtBefore)).toBe(false);
+  });
+
+  it("is complete once the database is ready again with a newer status timestamp", () => {
+    const ready = database({
+      version: "8.4",
+      status: "ready",
+      statusSetAt: "2024-01-01T00:00:20Z",
+    });
+
+    expect(isUpgradeComplete(ready, "8.4", statusSetAtBefore)).toBe(true);
+  });
+
+  it("is not complete when the database is ready but reports another version", () => {
+    const otherVersion = database({
+      version: "8.0",
+      status: "ready",
+      statusSetAt: "2024-01-01T00:00:20Z",
+    });
+
+    expect(isUpgradeComplete(otherVersion, "8.4", statusSetAtBefore)).toBe(
+      false,
+    );
+  });
+
+  it("is not complete when the upgrade failed", () => {
+    const failed = database({
+      version: "8.4",
+      status: "error",
+      statusSetAt: "2024-01-01T00:00:20Z",
+    });
+
+    expect(isUpgradeComplete(failed, "8.4", statusSetAtBefore)).toBe(false);
+  });
+});

--- a/src/lib/resources/database/mysql/upgrade.ts
+++ b/src/lib/resources/database/mysql/upgrade.ts
@@ -1,0 +1,30 @@
+import { MittwaldAPIV2 } from "@mittwald/api-client";
+
+type Database = MittwaldAPIV2.Components.Schemas.DatabaseMySqlDatabase;
+
+/**
+ * Determines whether an upgrade triggered by patching the database's version
+ * has finished.
+ *
+ * `version` holds the _desired_ version and is updated as soon as the patch is
+ * accepted, so it does not indicate that the upgrade has finished. The status
+ * also still reads "ready" for a moment after patching, which means waiting for
+ * "ready" alone would return before the upgrade even starts.
+ *
+ * `statusSetAt` records when the status was last set, so requiring it to differ
+ * from the value observed before patching proves the database has changed state
+ * at least once since. Both timestamps come from the API, so comparing them is
+ * not affected by clock skew on the client.
+ */
+export function isUpgradeComplete(
+  database: Database,
+  targetVersion: string,
+  statusSetAtBeforeUpgrade: string,
+): boolean {
+  return (
+    database.statusSetAt !== statusSetAtBeforeUpgrade &&
+    database.version === targetVersion &&
+    database.status === "ready" &&
+    database.isReady
+  );
+}

--- a/src/lib/resources/database/mysql/versions.test.ts
+++ b/src/lib/resources/database/mysql/versions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "@jest/globals";
+import { getUpgradeCandidates } from "./versions.js";
+import { MittwaldAPIV2 } from "@mittwald/api-client";
+
+type MySqlVersion = MittwaldAPIV2.Components.Schemas.DatabaseMySqlVersion;
+
+function version(number: string, disabled = false): MySqlVersion {
+  return { id: `id-${number}`, name: `MySQL ${number}`, number, disabled };
+}
+
+describe("getUpgradeCandidates", () => {
+  const versions = [
+    version("5.7"),
+    version("8.0"),
+    version("8.4"),
+    version("10.11"),
+  ];
+
+  it("only offers versions newer than the current one", () => {
+    expect(getUpgradeCandidates(versions, "8.0").map((v) => v.number)).toEqual([
+      "8.4",
+      "10.11",
+    ]);
+  });
+
+  it("compares versions numerically rather than lexically", () => {
+    expect(getUpgradeCandidates(versions, "8.4").map((v) => v.number)).toEqual([
+      "10.11",
+    ]);
+  });
+
+  it("omits disabled versions", () => {
+    const withDisabled = [version("8.0"), version("8.4", true)];
+
+    expect(
+      getUpgradeCandidates(withDisabled, "5.7").map((v) => v.number),
+    ).toEqual(["8.0"]);
+  });
+
+  it("returns nothing when the current version is the latest", () => {
+    expect(getUpgradeCandidates(versions, "10.11")).toEqual([]);
+  });
+
+  it("does not offer the current version itself", () => {
+    expect(
+      getUpgradeCandidates(versions, "5.7").map((v) => v.number),
+    ).not.toContain("5.7");
+  });
+});

--- a/src/lib/resources/database/mysql/versions.ts
+++ b/src/lib/resources/database/mysql/versions.ts
@@ -1,0 +1,47 @@
+import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
+import { assertStatus } from "@mittwald/api-client-commons";
+import semver from "semver";
+
+type MySqlVersion = MittwaldAPIV2.Components.Schemas.DatabaseMySqlVersion;
+
+/**
+ * MySQL versions are given in `<major>.<minor>` format, which is not valid
+ * semantic versioning; `semver.coerce` pads them to `<major>.<minor>.0`.
+ */
+function toSemver(version: string): semver.SemVer {
+  const coerced = semver.coerce(version);
+  if (!coerced) {
+    throw new Error(`could not parse MySQL version "${version}"`);
+  }
+  return coerced;
+}
+
+export function compareVersions(a: MySqlVersion, b: MySqlVersion): number {
+  return semver.compare(toSemver(a.number), toSemver(b.number));
+}
+
+/**
+ * Determines the versions a database running `currentVersion` may be upgraded
+ * to. MySQL does not support downgrades, so only newer versions are considered;
+ * versions that are disabled are not offered for new upgrades.
+ */
+export function getUpgradeCandidates(
+  versions: MySqlVersion[],
+  currentVersion: string,
+): MySqlVersion[] {
+  const current = toSemver(currentVersion);
+
+  return versions
+    .filter((v) => !v.disabled && semver.gt(toSemver(v.number), current))
+    .sort(compareVersions);
+}
+
+export async function getUpgradeCandidatesForVersion(
+  apiClient: MittwaldAPIV2Client,
+  currentVersion: string,
+): Promise<MySqlVersion[]> {
+  const response = await apiClient.database.listMysqlVersions({});
+  assertStatus(response, 200);
+
+  return getUpgradeCandidates(response.data, currentVersion);
+}


### PR DESCRIPTION
Adds a `database mysql upgrade` command for upgrading a MySQL database to a newer version.

## Background

The API has no dedicated upgrade operation. `PATCH /v2/mysql-databases/{id}` accepts an optional `version` field alongside `description` and `characterSettings`, and that is what this command drives.

## Behaviour

- Upgrade candidates come from `GET /v2/mysql-versions`, filtered to enabled versions newer than the database's current one. MySQL does not support downgrades, so older versions are never offered.
- Versions are compared numerically via semver coercion. The `<major>.<minor>` format is not valid semver, and a lexical sort would place `10.11` before `8.0`.
- `--version` takes an explicit version or `latest`; if omitted, the version is prompted for interactively, following `app upgrade`.
- If the database already runs the newest available version, the command reports that and exits without patching.
- An invalid `--version` fails with the list of valid targets rather than sending a doomed request.
- Upgrades are confirmed unless `--force` is passed, since they are disruptive.
- `--wait` polls until the upgrade has actually completed (see below).

## Notes for reviewers

The interesting part is `--wait`. Two API behaviours make the obvious implementation wrong, both found by testing against a real database:

- `version` holds the **desired** version and is updated as soon as the patch is accepted, so it does not indicate that the upgrade finished.
- `status` still reads `ready` from before the upgrade for a moment after patching.

Together these mean a naive "target version and `ready`" check returns before the upgrade even starts, leaving the database at `pending`. Unlike `AppAppInstallation`, `DatabaseMySqlDatabase` has no current/desired pair, so the `current == desired` approach used by `waitUntilAppStateHasNormalized` is not available here.

Instead, `statusSetAt` is captured before patching and required to have changed before `ready` is trusted, proving the database changed state at least once since. Both timestamps come from the API, so the comparison is immune to client clock skew. This is `isUpgradeComplete()` in `lib/resources/database/mysql/upgrade.ts`, covered by unit tests including the stale-`ready` regression.

The existing command tests in this area are all `it.skip`'d ("to be fixed later"), so rather than add another skipped test, the version-selection and completion logic are extracted into `lib/resources/database/mysql/` and covered by real unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)