### PR TITLE
fix(database): report the actual database status in list commands

### DIFF
--- a/src/commands/database/list.ts
+++ b/src/commands/database/list.ts
@@ -1,5 +1,5 @@
 import { assertStatus } from "@mittwald/api-client-commons";
-import { MittwaldAPIV2Client } from "@mittwald/api-client";
+import { MittwaldAPIV2, MittwaldAPIV2Client } from "@mittwald/api-client";
 import { ListColumns } from "../../rendering/formatter/Table.js";
 import { ListBaseCommand } from "../../lib/basecommands/ListBaseCommand.js";
 import { projectFlags } from "../../lib/resources/project/flags.js";
@@ -11,7 +11,7 @@ type ResponseItem = {
   version: string;
   description: string;
   hostname: string;
-  isReady: boolean;
+  status: MittwaldAPIV2.Components.Schemas.DatabaseDatabaseStatus;
   createdAt: string;
 };
 type Response = Awaited<
@@ -43,11 +43,7 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
 
     databases.push(
       ...mysqlResponse.data.map((d) => ({ ...d, kind: "mysql" as const })),
-      ...redisResponse.data.map((d) => ({
-        ...d,
-        kind: "redis" as const,
-        isReady: true,
-      })),
+      ...redisResponse.data.map((d) => ({ ...d, kind: "redis" as const })),
     );
 
     return databases;
@@ -80,12 +76,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
       },
       status: {
         header: "Status",
-        get: (row) => {
-          if (!row.isReady) {
-            return "pending";
-          }
-          return "ready";
-        },
       },
       createdAt,
     };

--- a/src/commands/database/mysql/list.ts
+++ b/src/commands/database/mysql/list.ts
@@ -45,12 +45,6 @@ export class List extends ListBaseCommand<typeof List, ResponseItem, Response> {
       },
       status: {
         header: "Status",
-        get: (row) => {
-          if (!row.isReady) {
-            return "pending";
-          }
-          return "ready";
-        },
       },
       characterSet: {
         header: "Character Set",


### PR DESCRIPTION
`database mysql list` displayed `pending` for a database that the API reported as `migrating`.

## Cause

The status column did not use the `status` field returned by the API. It derived the value from the `isReady` boolean instead:

```ts
get: (row) => {
  if (!row.isReady) {
    return "pending";
  }
  return "ready";
},
```

`DatabaseDatabaseStatus` has five values — `pending`, `ready`, `migrating`, `importing` and `error` — so this collapsed everything that was not ready into `pending`. Besides `migrating`, this also affected `error`: a failed database was indistinguishable from one that is still being worked on.

The same code existed in `database list`, which had a second problem. `DatabaseRedisDatabase` has no `isReady` field, so Redis rows were hardcoded to `isReady: true` and always displayed as `ready`, whatever their actual state.

## Fix

Both MySQL and Redis databases report `status`, so the column now uses it directly and the Redis `isReady` hardcode is gone. Since the column key already matches the field, the custom getter is no longer needed.

Verified against a mock serving all five states; each is now reported verbatim, and a pending Redis database no longer shows as ready.

Found while testing #2005, where an upgrade puts the database into `migrating`, but this is an independent pre-existing bug, hence the separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)