### PR TITLE
chore(dependabot): ignore typescript 7.x until tooling supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,13 @@ updates:
           - "eslint"
           - "@eslint/*"
           - "@typescript-eslint/*"
+    ignore:
+      # typescript 7 is the native (Go) port: the package ships only the tsgo
+      # binary and no longer exposes the JS compiler API. typescript-eslint
+      # (peer: <6.1.0) and ts-jest (peer: <7) both read that API and crash on
+      # it, so lint and unit tests break. Drop this once both support v7.
+      - dependency-name: "typescript"
+        versions: ["7.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Follow-up to #1993, which fails CI and cannot be fixed by a code change.

## Why #1993 fails

TypeScript 7 is the native (Go) port. The `typescript@7` package ships only the `tsgo` binary — `node_modules/typescript/lib` contains just `getExePath.js`, `tsc.js`, and `version.cjs`. The JS compiler API is gone.

Tools that reach into that API crash, which is exactly what CI shows (reproduced locally):

- **Run linters** — `TypeError: Cannot read properties of undefined (reading 'Cjs')` in `@typescript-eslint/typescript-estree` (`ts.ScriptKind` is undefined)
- **Run unit tests** — `TypeError: Cannot read properties of undefined (reading 'fileExists')` in ts-jest (`ts.sys` is undefined); 15/15 suites fail to run
- **Test if dependencies are resolvable** — peer dependency conflicts

`Compile TypeScript` passes because `tsc` itself works fine — only the API consumers break.

## The ecosystem is not ready

Even at latest:

| package | version | typescript peer range |
| --- | --- | --- |
| typescript-eslint | 8.64.0 | `>=4.8.4 <6.1.0` |
| ts-jest | 29.4.11 | `>=4.3 <7` |

Both exclude 7.x. There is no version combination that makes this bump work today.

## This PR

Adds a Dependabot ignore for `typescript` `7.x` with a comment explaining why and when to drop it. `package.json` already pins `^6.0.2`, so nothing else changes.

**#1993 should be closed** — it will not become mergeable until typescript-eslint and ts-jest ship v7 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)