### PR TITLE
feat(deploy): build and push early exit for experimental deploy

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -13,6 +13,7 @@ Deploys a new container.
 USAGE
   $ mw experimental deploy [--token <value>] [-q] [-p <value>] [-w] [--wait-timeout <value>] [-e <value>...] [--env-file
     <value>...] [--uri-prefix <value>] [--service-name <value>] [--image-name <value>] [--image-tag <value>]
+    [--build-only]
 
 FLAGS
   -e, --env=<value>...        set environment variables in the container
@@ -20,6 +21,7 @@ FLAGS
                               context
   -q, --quiet                 suppress process output and only display a machine-readable summary
   -w, --wait                  wait for the resource to be ready.
+      --build-only            build and push the image only
       --env-file=<value>...   read environment variables from a file
       --image-name=<value>    name of the Docker image to build and push
       --image-tag=<value>     tag of the Docker image to build and push
@@ -49,6 +51,10 @@ EXAMPLES
 
     $ mw experimental deploy --service-name my-feature --image-name my-app --image-tag feature
 
+  Build and push image only, without deploying a service
+
+    $ mw experimental deploy --build-only
+
 FLAG DESCRIPTIONS
   -e, --env=<value>...  set environment variables in the container
 
@@ -63,6 +69,10 @@ FLAG DESCRIPTIONS
 
     This flag controls if you want to see the process output or only a summary. When using mw non-interactively (e.g. in
     scripts), you can use this flag to easily get the IDs of created resources for further processing.
+
+  --build-only  build and push the image only
+
+    Skips service deployment and domain creation after the image is pushed.
 
   --env-file=<value>...  read environment variables from a file
 

--- a/src/commands/experimental/deploy.tsx
+++ b/src/commands/experimental/deploy.tsx
@@ -26,7 +26,9 @@ import {
 } from "@mittwald/container-deploy";
 
 type Result = {
-  deployedServiceId: string;
+  deployedServiceId?: string;
+  builtImageName?: string;
+  buildOnly: boolean;
 };
 
 export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
@@ -74,6 +76,13 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
       description: `Defaults to '${DEFAULT_IMAGE_TAG}'.`,
       required: false,
     }),
+    "build-only": Flags.boolean({
+      summary: "build and push the image only",
+      description:
+        "Skips service deployment and domain creation after the image is pushed.",
+      default: false,
+      required: false,
+    }),
   };
   static args = {};
   static examples = [
@@ -96,12 +105,16 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
       command:
         "<%= config.bin %> <%= command.id %> --service-name my-feature --image-name my-app --image-tag feature",
     },
+    {
+      description: "Build and push image only, without deploying a service",
+      command: "<%= config.bin %> <%= command.id %> --build-only",
+    },
   ];
 
   protected async exec(): Promise<Result> {
     const p = makeProcessRenderer(this.flags, "Deploying ...");
 
-    let deployedServiceId: string = "";
+    let deployedServiceId: string | undefined;
 
     const projectId = await this.withProjectId(Deploy);
     const projectShortId = await getProjectShortIdFromUuid(
@@ -162,6 +175,21 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
       p.addInfo(`Pushed image ${builtImage.imageName} to registry`);
     });
 
+    if (this.flags["build-only"]) {
+      await p.complete(
+        <Success>
+          Image <Value>{builtImage.imageName}</Value> was successfully built and
+          pushed
+        </Success>,
+      );
+
+      return {
+        deployedServiceId,
+        builtImageName: builtImage.imageName,
+        buildOnly: true,
+      };
+    }
+
     const deployResult = await p.runStep("Deploying ...", async () => {
       const result = await deployService(
         this.apiClient,
@@ -197,12 +225,16 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
       </Success>,
     );
 
-    return { deployedServiceId };
+    return {
+      deployedServiceId,
+      builtImageName: builtImage.imageName,
+      buildOnly: false,
+    };
   }
 
-  protected render({ deployedServiceId }: Result): ReactNode {
+  protected render({ deployedServiceId, builtImageName, buildOnly }: Result): ReactNode {
     if (this.flags.quiet) {
-      return deployedServiceId;
+      return buildOnly ? builtImageName : deployedServiceId;
     }
   }
 }

--- a/src/commands/experimental/deploy.tsx
+++ b/src/commands/experimental/deploy.tsx
@@ -232,7 +232,11 @@ export class Deploy extends ExecRenderBaseCommand<typeof Deploy, Result> {
     };
   }
 
-  protected render({ deployedServiceId, builtImageName, buildOnly }: Result): ReactNode {
+  protected render({
+    deployedServiceId,
+    builtImageName,
+    buildOnly,
+  }: Result): ReactNode {
     if (this.flags.quiet) {
       return buildOnly ? builtImageName : deployedServiceId;
     }


### PR DESCRIPTION
Resolves #1990 

Yields:

```
  ┌──────────────────────────────────────────────────────────────────────────────┐
  │  SUCCESS                                                                     │
  │  Image registry.p-sr0t8w.project.space/app-image:latest was successfully     │
  │  built and pushed                                                            │
  └──────────────────────────────────────────────────────────────────────────────┘
```

After pull&recreate in mStudio shiny new container spawns.