### PR TITLE
docs(claude): stop asking agents to re-generate the README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,18 +16,17 @@ code in this repository.
 **Development:**
 
 - `yarn clean` - Clean compiled files and build artifacts
-- `yarn generate:readme >/dev/null 2>&1` - Generate documentation from command
-  definitions
 
 ## Development best practices
 
 - Follow the conventional commit format when writing commit messages
-- Make sure to re-generate the documentation before each commit
+- Do not re-generate the documentation (`yarn generate:readme`) yourself; the
+  `Update README for pull requests` GitHub workflow re-generates `README.md` and
+  `docs/*.md` on every pull request and commits the result back to the branch
 - Before wrapping up a task, run this checklist in order:
   1. `yarn lint`
   2. `yarn compile`
   3. `yarn test`
-  4. `yarn generate:readme >/dev/null 2>&1`
 
 ## Architecture Overview
 


### PR DESCRIPTION
`CLAUDE.md` currently instructs agents to run `yarn generate:readme` before every commit and as the last step of the wrap-up checklist.

That is redundant: the `Update README for pull requests` workflow (`.github/workflows/readme_pr.yml`) runs `yarn generate:readme` on every pull request (`opened`, `ready_for_review`, `synchronize`) and commits the regenerated `README.md` and `docs/*.md` back to the branch.

Changes:

- Drop `yarn generate:readme` from the development commands list and from the wrap-up checklist.
- Replace "Make sure to re-generate the documentation before each commit" with an explicit note not to do it, and why.

The wrap-up checklist (`yarn lint` → `yarn compile` → `yarn test`) is unaffected — `yarn test` does not include `test:readme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)